### PR TITLE
feat(labels): add 6 fields for remaining hardcoded messages (auth, nav, whatsapp)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -564,6 +564,12 @@ class LabelMessages(BaseModel):
     no_tutorials_label: Optional[MessageItem] = None
     combo_no_bets_added: Optional[MessageItem] = None
     combo_partial_bets_warning: Optional[MessageItem] = None
+    post_bet_menu_text: Optional[MessageItem] = None
+    select_sport_fallback: Optional[MessageItem] = None
+    greeting_menu_fallback: Optional[MessageItem] = None
+    more_options_label: Optional[MessageItem] = None
+    account_locked_text: Optional[MessageItem] = None
+    invalid_otp_text: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -1255,6 +1261,14 @@ class MessageTemplates(BaseModel):
                 combo_partial_bets_warning=MessageItem(
                     text="⚠️ {ADDED} of {TOTAL} bets were added to the combo.\n\nBets added:\n{PICKS}\n\nBets that failed:\n{FAILED}\n\nYou can proceed with the successful bets or remove the combo."
                 ),
+                post_bet_menu_text=MessageItem(
+                    text="What would you like to do?"
+                ),
+                select_sport_fallback=MessageItem(text="Select a sport"),
+                greeting_menu_fallback=MessageItem(text="Menu"),
+                more_options_label=MessageItem(text="More options"),
+                account_locked_text=MessageItem(text="Account locked"),
+                invalid_otp_text=MessageItem(text="Invalid OTP"),
             ),
             end=EndMessages(
                 end_conversation=MessageItem(text="Bye!"),

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1322,6 +1322,12 @@ class TestLabelMessagesNewFields:
         "no_tutorials_label",
         "combo_no_bets_added",
         "combo_partial_bets_warning",
+        "post_bet_menu_text",
+        "select_sport_fallback",
+        "greeting_menu_fallback",
+        "more_options_label",
+        "account_locked_text",
+        "invalid_otp_text",
     ]
 
     def test_each_new_field_accepts_message_item(self):
@@ -1389,3 +1395,9 @@ class TestLabelMessagesNewFields:
         assert labels.combo_partial_bets_warning.text.startswith(
             "\u26a0\ufe0f"
         )
+        assert labels.post_bet_menu_text.text == "What would you like to do?"
+        assert labels.select_sport_fallback.text == "Select a sport"
+        assert labels.greeting_menu_fallback.text == "Menu"
+        assert labels.more_options_label.text == "More options"
+        assert labels.account_locked_text.text == "Account locked"
+        assert labels.invalid_otp_text.text == "Invalid OTP"


### PR DESCRIPTION
## Summary

Second batch of `LabelMessages` field additions, extending the work from [PR #121](https://github.com/AIChatBet/chatbet-base-models/pull/121) (already merged). Adds 6 new `Optional[MessageItem] = None` fields so operators can customize post-bet prompts, sport selection fallback, greeting menu, WhatsApp pagination, and authentication error messages from DynamoDB.

**Companion change**: commits on `feat/externalize-hardcoded-messages` branch in [AIChatBet/chatbet-channel-services](https://github.com/AIChatBet/chatbet-channel-services) (PR #504, pending push after this merges).

## Fields added (6)

| Field | Default | Context |
|---|---|---|
| `post_bet_menu_text` | `"What would you like to do?"` | Menu prompt shown after placing a bet |
| `select_sport_fallback` | `"Select a sport"` | Fallback when `messages.bets.select_sport` is None |
| `greeting_menu_fallback` | `"Menu"` | Greeting fallback when no greeting template configured |
| `more_options_label` | `"More options"` | WhatsApp overflow/pagination button label |
| `account_locked_text` | `"Account locked"` | Authentication error when platform locks the account |
| `invalid_otp_text` | `"Invalid OTP"` | Bad OTP code error message |

## Backward-compatibility

Same 3-layer contract as PR #121:
1. **Model**: all fields `Optional[MessageItem] = None` → existing records validate unchanged
2. **Factory**: `from_minimal()` populates defaults identical to current hardcodes
3. **Runtime**: `get_label()` in bet-bot falls back to exact current-behavior string

## Tests

- All existing + new fields covered in `TestLabelMessagesNewFields`
- `from_minimal()` defaults spot-checked

## Test plan

- [ ] CI green on this branch
- [ ] Companion bet-bot commit pushed to PR #504 after merge

ClickUp: [86agr900w](https://app.clickup.com/t/86agr900w)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new customizable message labels for enhanced chatbot interactions: post-bet menu options, sport selection fallback text, greeting menu defaults, additional menu options, account locked notifications, and invalid OTP feedback messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->