### PR TITLE
feat: add application_code to IsolutionsConfig

### DIFF
--- a/chatbet_base_models/sportbook_config.py
+++ b/chatbet_base_models/sportbook_config.py
@@ -162,6 +162,7 @@ class IsolutionsConfig(BaseModel):
     fetch_interval_seconds: int = 60
     check_fixture_availability: Optional[bool] = False
     last_server_date: Optional[str] = None
+    application_code: Optional[str] = None
 
 
 class BetbyConfig(BaseModel):


### PR DESCRIPTION
## Summary
- Add `application_code: Optional[str] = None` to `IsolutionsConfig`
- ISolutions requested adding `ApplicationCode` property to `NewBetV2` request body
- Configurable per company via backoffice

## Companion PRs
- sportbook-services: sends ApplicationCode in place_bet/place_combo payload
- chatbet-backoffice: UI field + i18n for editing application_code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional application code configuration field for the isolutions provider, enabling additional customization of provider-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->