### PR TITLE
feat(labels): merge externalized label fields to staging

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -564,6 +564,12 @@ class LabelMessages(BaseModel):
     no_tutorials_label: Optional[MessageItem] = None
     combo_no_bets_added: Optional[MessageItem] = None
     combo_partial_bets_warning: Optional[MessageItem] = None
+    post_bet_menu_text: Optional[MessageItem] = None
+    select_sport_fallback: Optional[MessageItem] = None
+    greeting_menu_fallback: Optional[MessageItem] = None
+    more_options_label: Optional[MessageItem] = None
+    account_locked_text: Optional[MessageItem] = None
+    invalid_otp_text: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -1255,6 +1261,14 @@ class MessageTemplates(BaseModel):
                 combo_partial_bets_warning=MessageItem(
                     text="⚠️ {ADDED} of {TOTAL} bets were added to the combo.\n\nBets added:\n{PICKS}\n\nBets that failed:\n{FAILED}\n\nYou can proceed with the successful bets or remove the combo."
                 ),
+                post_bet_menu_text=MessageItem(
+                    text="What would you like to do?"
+                ),
+                select_sport_fallback=MessageItem(text="Select a sport"),
+                greeting_menu_fallback=MessageItem(text="Menu"),
+                more_options_label=MessageItem(text="More options"),
+                account_locked_text=MessageItem(text="Account locked"),
+                invalid_otp_text=MessageItem(text="Invalid OTP"),
             ),
             end=EndMessages(
                 end_conversation=MessageItem(text="Bye!"),

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -546,6 +546,24 @@ class LabelMessages(BaseModel):
     tournaments_back_options: Optional[MessageItem] = None
     matches_back_options: Optional[MessageItem] = None
     edit_bet_label_text: Optional[MessageItem] = None
+    back_option: Optional[MessageItem] = None
+    home_page_text: Optional[MessageItem] = None
+    profit_text: Optional[MessageItem] = None
+    remove_bet_label: Optional[MessageItem] = None
+    add_another_bet_label: Optional[MessageItem] = None
+    confirm_bet_label: Optional[MessageItem] = None
+    remove_another_bet_label: Optional[MessageItem] = None
+    session_expired: Optional[MessageItem] = None
+    still_processing: Optional[MessageItem] = None
+    authenticated: Optional[MessageItem] = None
+    expired_button: Optional[MessageItem] = None
+    you_selected_prefix: Optional[MessageItem] = None
+    my_combos_label: Optional[MessageItem] = None
+    select_link_label: Optional[MessageItem] = None
+    select_tutorial_label: Optional[MessageItem] = None
+    no_tutorials_label: Optional[MessageItem] = None
+    combo_no_bets_added: Optional[MessageItem] = None
+    combo_partial_bets_warning: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -1204,6 +1222,39 @@ class MessageTemplates(BaseModel):
                 sports_back_options=MessageItem(text="<< Prev sports"),
                 tournaments_back_options=MessageItem(text="<< Prev tournaments"),
                 matches_back_options=MessageItem(text="<< Prev matches"),
+                edit_bet_label_text=MessageItem(text="Edit bet"),
+                back_option=MessageItem(text="<< Back"),
+                home_page_text=MessageItem(text="Go to website \U0001f310"),
+                profit_text=MessageItem(text="Bet \U0001f911"),
+                remove_bet_label=MessageItem(text="Remove bet"),
+                add_another_bet_label=MessageItem(text="Add another bet"),
+                confirm_bet_label=MessageItem(text="Confirm bet"),
+                remove_another_bet_label=MessageItem(text="Remove another bet"),
+                session_expired=MessageItem(
+                    text="Welcome back! \U0001f44b We've cleared your current betslip so you can start fresh. Your account and chat history are still saved."
+                ),
+                still_processing=MessageItem(
+                    text="I'm still processing your previous message, please give me a moment."
+                ),
+                authenticated=MessageItem(text="You're now authenticated \u2705"),
+                expired_button=MessageItem(
+                    text="This button has expired. Please start again from the menu."
+                ),
+                you_selected_prefix=MessageItem(text="You selected:"),
+                my_combos_label=MessageItem(text="My Combos"),
+                select_link_label=MessageItem(text="Select a link:"),
+                select_tutorial_label=MessageItem(
+                    text="Select a tutorial to watch:"
+                ),
+                no_tutorials_label=MessageItem(
+                    text="No tutorials available at the moment."
+                ),
+                combo_no_bets_added=MessageItem(
+                    text="Could not add any bet from the combo."
+                ),
+                combo_partial_bets_warning=MessageItem(
+                    text="⚠️ {ADDED} of {TOTAL} bets were added to the combo.\n\nBets added:\n{PICKS}\n\nBets that failed:\n{FAILED}\n\nYou can proceed with the successful bets or remove the combo."
+                ),
             ),
             end=EndMessages(
                 end_conversation=MessageItem(text="Bye!"),

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1,9 +1,12 @@
 import pytest
 from datetime import datetime
 
+from pydantic import ValidationError
+
 from chatbet_base_models.message_template import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    LabelMessages,
     MessageItem,
     OnboardingMessages,
     ValidationMessages,
@@ -1295,3 +1298,88 @@ class TestMessageTemplatesWithLinks:
             link.title == "Support" for link in templates.links.links
         )  # From required defaults
         assert any(link.title == "FAQ" for link in templates.links.links)
+
+
+class TestLabelMessagesNewFields:
+    """Tests for the 16 new fields added to LabelMessages."""
+
+    NEW_FIELDS = [
+        "back_option",
+        "home_page_text",
+        "profit_text",
+        "remove_bet_label",
+        "add_another_bet_label",
+        "confirm_bet_label",
+        "remove_another_bet_label",
+        "session_expired",
+        "still_processing",
+        "authenticated",
+        "expired_button",
+        "you_selected_prefix",
+        "my_combos_label",
+        "select_link_label",
+        "select_tutorial_label",
+        "no_tutorials_label",
+    ]
+
+    def test_each_new_field_accepts_message_item(self):
+        """Each new field should accept a MessageItem value."""
+        for field_name in self.NEW_FIELDS:
+            labels = LabelMessages(**{field_name: MessageItem(text="test")})
+            value = getattr(labels, field_name)
+            assert value is not None
+            assert value.text == "test"
+
+    def test_each_new_field_accepts_none(self):
+        """Each new field should accept None (default)."""
+        labels = LabelMessages()
+        for field_name in self.NEW_FIELDS:
+            assert getattr(labels, field_name) is None
+
+    def test_model_validate_coerces_plain_string_to_message_item(self):
+        """model_validate should coerce a plain string to MessageItem.text."""
+        for field_name in self.NEW_FIELDS:
+            labels = LabelMessages.model_validate({field_name: "hello"})
+            value = getattr(labels, field_name)
+            assert isinstance(value, MessageItem)
+            assert value.text == "hello"
+
+    def test_extra_fields_raise_validation_error(self):
+        """Extra fields not in the model should raise ValidationError."""
+        with pytest.raises(ValidationError):
+            LabelMessages(nonexistent_field=MessageItem(text="x"))
+
+    def test_from_minimal_labels_is_not_none(self):
+        """from_minimal() should return non-None labels (regression guard)."""
+        templates = MessageTemplates.from_minimal()
+        assert templates.labels is not None
+
+    def test_from_minimal_session_expired_text(self):
+        """from_minimal().labels.session_expired.text should match the English default."""
+        templates = MessageTemplates.from_minimal()
+        expected = (
+            "Welcome back! \U0001f44b We've cleared your current betslip "
+            "so you can start fresh. Your account and chat history are still saved."
+        )
+        assert templates.labels.session_expired.text == expected
+
+    def test_from_minimal_all_new_fields_populated(self):
+        """from_minimal() should populate every new label field."""
+        templates = MessageTemplates.from_minimal()
+        for field_name in self.NEW_FIELDS:
+            value = getattr(templates.labels, field_name)
+            assert value is not None, f"from_minimal() labels.{field_name} is None"
+            assert isinstance(value, MessageItem)
+            assert value.text, f"from_minimal() labels.{field_name}.text is empty"
+
+    def test_from_minimal_specific_defaults(self):
+        """Spot-check a few specific default values from from_minimal()."""
+        labels = MessageTemplates.from_minimal().labels
+        assert labels.back_option.text == "<< Back"
+        assert labels.home_page_text.text == "Go to website \U0001f310"
+        assert labels.profit_text.text == "Bet \U0001f911"
+        assert labels.confirm_bet_label.text == "Confirm bet"
+        assert labels.authenticated.text == "You're now authenticated \u2705"
+        assert labels.my_combos_label.text == "My Combos"
+        assert labels.no_tutorials_label.text == "No tutorials available at the moment."
+        assert labels.edit_bet_label_text.text == "Edit bet"

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1322,6 +1322,12 @@ class TestLabelMessagesNewFields:
         "no_tutorials_label",
         "combo_no_bets_added",
         "combo_partial_bets_warning",
+        "post_bet_menu_text",
+        "select_sport_fallback",
+        "greeting_menu_fallback",
+        "more_options_label",
+        "account_locked_text",
+        "invalid_otp_text",
     ]
 
     def test_each_new_field_accepts_message_item(self):
@@ -1389,3 +1395,9 @@ class TestLabelMessagesNewFields:
         assert labels.combo_partial_bets_warning.text.startswith(
             "\u26a0\ufe0f"
         )
+        assert labels.post_bet_menu_text.text == "What would you like to do?"
+        assert labels.select_sport_fallback.text == "Select a sport"
+        assert labels.greeting_menu_fallback.text == "Menu"
+        assert labels.more_options_label.text == "More options"
+        assert labels.account_locked_text.text == "Account locked"
+        assert labels.invalid_otp_text.text == "Invalid OTP"

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1301,7 +1301,7 @@ class TestMessageTemplatesWithLinks:
 
 
 class TestLabelMessagesNewFields:
-    """Tests for the 16 new fields added to LabelMessages."""
+    """Tests for the 18 new fields added to LabelMessages."""
 
     NEW_FIELDS = [
         "back_option",

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1320,6 +1320,8 @@ class TestLabelMessagesNewFields:
         "select_link_label",
         "select_tutorial_label",
         "no_tutorials_label",
+        "combo_no_bets_added",
+        "combo_partial_bets_warning",
     ]
 
     def test_each_new_field_accepts_message_item(self):
@@ -1383,3 +1385,7 @@ class TestLabelMessagesNewFields:
         assert labels.my_combos_label.text == "My Combos"
         assert labels.no_tutorials_label.text == "No tutorials available at the moment."
         assert labels.edit_bet_label_text.text == "Edit bet"
+        assert labels.combo_no_bets_added.text == "Could not add any bet from the combo."
+        assert labels.combo_partial_bets_warning.text.startswith(
+            "\u26a0\ufe0f"
+        )


### PR DESCRIPTION
## Summary
- Adds 24 externalized label fields to `LabelMessages` model that the backoffice frontend already sends
- Without this merge, staging backend rejects label saves with `extra_forbidden` validation errors (Pydantic `extra="forbid"`)

## Changes included
- `feat(labels): extend LabelMessages with optional fields for message externalization`
- `test(labels): cover combo_no_bets_added and combo_partial_bets_warning in regression tests`
- `docs(tests): fix field count in TestLabelMessagesNewFields docstring`
- `feat(labels): add 6 fields for remaining hardcoded messages (auth, nav, whatsapp)`

## Test plan
- [ ] Merge and redeploy backend in staging
- [ ] Verify saving message templates with label fields no longer returns `extra_forbidden`
- [ ] Confirm existing label fields still work correctly