### PR TITLE
fix(WhatsAppConfig): keep legacy fields as Optional for backward compat

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -157,8 +157,14 @@ class WhatsAppConfig(BaseModel):
     )
     phone_id: str
     auth_token: str
+    # Legacy fields (pre hub_verify_token migration) — kept Optional so existing
+    # DynamoDB configs still validate while backoffice/bot migrate to the new
+    # names. Remove once every stored config has been updated.
+    connection_token: Optional[str] = None
+    app_id: Optional[str] = None
+    # Current fields for Meta webhook validation
     hub_verify_token: Optional[str] = None
-    waba_id: Optional[str] = None  # Optional for backward compatibility
+    waba_id: Optional[str] = None
     webhook_url: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary

The recent WhatsAppConfig refactor removed \`connection_token\` and \`app_id\` in favour of \`hub_verify_token\` and \`waba_id\`. The model keeps \`extra=\"forbid\"\`, which means **any DynamoDB site config that still carries the legacy field names fails Pydantic validation the moment a consumer tries to load it** (bet-bot, chatbet-backoffice, sportbook_services).

This PR restores both legacy fields as \`Optional[str] = None\` so stored configs keep validating while the rest of the ecosystem migrates to the new names. No field is required — old, new, and mixed-shape configs all load cleanly. \`extra=\"forbid\"\` stays intact (typos are still rejected).

## Change

\`\`\`python
class WhatsAppConfig(BaseModel):
    model_config = ConfigDict(extra=\"forbid\")
    provider: Literal[\"meta\"] = Field(default=\"meta\", ...)
    phone_id: str
    auth_token: str
    # Legacy (Optional) — kept so existing DynamoDB configs still validate
    connection_token: Optional[str] = None
    app_id: Optional[str] = None
    # Current
    hub_verify_token: Optional[str] = None
    waba_id: Optional[str] = None
    webhook_url: Optional[str] = None
\`\`\`

Once every stored config has been updated to use the new names, the two legacy fields can be dropped cleanly.

## Compatibility matrix

| Config shape | Before | After this PR |
|---|---|---|
| Legacy (\`connection_token\`, \`app_id\`) | ❌ ValidationError | ✅ loads, new fields = None |
| New (\`hub_verify_token\`, \`waba_id\`) | ✅ | ✅ |
| Mixed (both sets present) | ❌ | ✅ |
| Config with a typo field | ❌ (extra=forbid) | ❌ (extra=forbid still active) |

## Test plan

- [x] Smoke test: legacy config validates; new config validates; mixed config validates; typo field still rejected
- [ ] After merge, cherry-pick this to \`staging\` and \`main\` so every deployed branch can safely load any existing DynamoDB config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * WhatsApp configuration now accepts additional optional legacy fields, ensuring existing stored configurations remain valid and compatible. This change provides better backward compatibility during the transition to current standards, allowing configurations using legacy field formats to continue working seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->