### PR TITLE
feat(86ah4m4zy): add LinkItem.follow_up for operator-managed post-link messages

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -667,6 +667,14 @@ class LinkItem(BaseModel):
     message_text: str = Field(min_length=1, max_length=5000)
     button_label: str = Field(min_length=1, max_length=100)
     button_url: str = Field(min_length=1, max_length=2000)
+    follow_up: Optional[MessageItem] = Field(
+        default=None,
+        description=(
+            "Optional follow-up message sent immediately after the link "
+            "message (CU-86ah4m4zy). Operator-managed via Backoffice. "
+            "When None, no follow-up is sent (preserves current behavior)."
+        ),
+    )
 
     @field_validator("title")
     @classmethod

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -512,6 +512,67 @@ class TestLinkItem:
                 extra_field="not allowed",
             )
 
+    def test_follow_up_defaults_to_none(self):
+        """CU-86ah4m4zy: follow_up is optional and defaults to None so
+        operators that haven't configured a follow-up message keep the
+        existing single-message redirection behavior."""
+        link = LinkItem(
+            title="Support",
+            message_text="Need help?",
+            button_label="Contact Support",
+            button_url="https://example.com/support",
+        )
+        assert link.follow_up is None
+
+    def test_follow_up_accepts_message_item_with_reply_markup(self):
+        """CU-86ah4m4zy: follow_up accepts a MessageItem with text and
+        an inline_keyboard so the bot can chain a second message after
+        the link with operator-defined buttons."""
+        link = LinkItem(
+            title="Support",
+            message_text="Need help?",
+            button_label="Contact Support",
+            button_url="https://example.com/support",
+            follow_up=MessageItem(
+                text="Anything else?",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="Menu", callback_data="menu"
+                            ),
+                            InlineKeyboardButton(
+                                text="Bet", callback_data="bet"
+                            ),
+                        ]
+                    ]
+                ),
+            ),
+        )
+        assert link.follow_up is not None
+        assert link.follow_up.text == "Anything else?"
+        assert link.follow_up.reply_markup is not None
+        rows = link.follow_up.reply_markup.inline_keyboard
+        assert len(rows) == 1
+        callbacks = sorted(btn.callback_data for btn in rows[0])
+        assert callbacks == ["bet", "menu"]
+
+    def test_follow_up_serializes_and_round_trips(self):
+        """``model_dump`` preserves follow_up so DynamoDB persistence
+        and BO round-tripping work end-to-end."""
+        original = LinkItem(
+            title="Support",
+            message_text="Need help?",
+            button_label="Contact Support",
+            button_url="https://example.com/support",
+            follow_up=MessageItem(text="See you soon!"),
+        )
+        dumped = original.model_dump()
+        assert dumped["follow_up"]["text"] == "See you soon!"
+        assert dumped["follow_up"].get("reply_markup") is None
+        rebuilt = LinkItem.model_validate(dumped)
+        assert rebuilt == original
+
 
 class TestLinksMessages:
     """Test links messages container"""


### PR DESCRIPTION
## Summary

- Adds an optional `follow_up: Optional[MessageItem] = None` field to `LinkItem` so operators can configure, **per link**, a second message (text + inline_keyboard) that is sent right after the link's URL-button message.
- Default `None` preserves the existing single-message redirection behavior — no schema break, no forced migration for operators that have not edited the new field.
- 3 new unit tests under `TestLinkItem` covering the default, nested MessageItem with InlineKeyboardMarkup, and model_dump round-trip.

## Context

Tracked in [CU-86ah4m4zy](https://app.clickup.com/t/86ah4m4zy). The original ticket asked the bot to send a "main_menu" message after every Link, but the actual product requirement is more flexible: each operator should be able to define **their own** follow-up message and buttons per link (Support, Withdrawal, Deposit, Sign up, Main site, Bet results) so the conversation does not dead-end after the bot sends a redirection link.

This is the **first of three coordinated PRs**:

1. **`chatbet-base-models` — this PR.** Adds the `follow_up` field to `LinkItem`.
2. **`bet-bot`** (next, blocked on this) — `handle_redirection_intent` will read `link_item.follow_up` and chain it as `additional_message` on the bot response. Mirrors the precedent in `handle_greeting_message`.
3. **`chatbet-backoffice`** (frontend + backend) — UI for operators to edit the follow-up message and buttons per link.

The bet-bot PR is blocked on this merge because the bet-bot Docker test image installs `chatbet-base-models` from `develop` via pip — without this field merged, bet-bot's CI cannot resolve `link_item.follow_up`.

## Files

- `chatbet_base_models/message_template.py` — `LinkItem.follow_up` field added with default `None` and a description that points to CU-86ah4m4zy.
- `tests/test_message_template.py` — 3 new tests under `TestLinkItem` (`test_follow_up_defaults_to_none`, `test_follow_up_accepts_message_item_with_reply_markup`, `test_follow_up_serializes_and_round_trips`).

## Test plan

- [x] Existing 99 tests still pass.
- [x] 3 new tests pass (`pytest tests/test_message_template.py::TestLinkItem`).
- [x] Total: **102 passed, 7 warnings**.
- [x] No regression in any other LinkItem / LinksMessages test (validation, defaults, factory).
- [ ] After merge: unblock bet-bot PR (`handle_redirection_intent` consumes `link_item.follow_up`) — covered by the integration test there.

## Out of scope

- bet-bot consumer (`handle_redirection_intent`) — separate PR.
- Backoffice UI/backend to let operators edit the field — separate PRs in `chatbet-backoffice`.
- DynamoDB migrations — none required because the field defaults to `None` and is omitted on serialize when not set (operators with old records read fine, write back identical shape unless they explicitly set `follow_up`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Link messages now support optional follow-up messages that automatically send immediately after the primary link message. When omitted, existing behavior remains unchanged, preserving backward compatibility.

* **Tests**
  * Added test coverage for follow-up message functionality, including field defaults, message validation, and data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->