### PR TITLE
release: develop → staging — LinkItem.follow_up

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -667,6 +667,14 @@ class LinkItem(BaseModel):
     message_text: str = Field(min_length=1, max_length=5000)
     button_label: str = Field(min_length=1, max_length=100)
     button_url: str = Field(min_length=1, max_length=2000)
+    follow_up: Optional[MessageItem] = Field(
+        default=None,
+        description=(
+            "Optional follow-up message sent immediately after the link "
+            "message (CU-86ah4m4zy). Operator-managed via Backoffice. "
+            "When None, no follow-up is sent (preserves current behavior)."
+        ),
+    )
 
     @field_validator("title")
     @classmethod

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -512,6 +512,67 @@ class TestLinkItem:
                 extra_field="not allowed",
             )
 
+    def test_follow_up_defaults_to_none(self):
+        """CU-86ah4m4zy: follow_up is optional and defaults to None so
+        operators that haven't configured a follow-up message keep the
+        existing single-message redirection behavior."""
+        link = LinkItem(
+            title="Support",
+            message_text="Need help?",
+            button_label="Contact Support",
+            button_url="https://example.com/support",
+        )
+        assert link.follow_up is None
+
+    def test_follow_up_accepts_message_item_with_reply_markup(self):
+        """CU-86ah4m4zy: follow_up accepts a MessageItem with text and
+        an inline_keyboard so the bot can chain a second message after
+        the link with operator-defined buttons."""
+        link = LinkItem(
+            title="Support",
+            message_text="Need help?",
+            button_label="Contact Support",
+            button_url="https://example.com/support",
+            follow_up=MessageItem(
+                text="Anything else?",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="Menu", callback_data="menu"
+                            ),
+                            InlineKeyboardButton(
+                                text="Bet", callback_data="bet"
+                            ),
+                        ]
+                    ]
+                ),
+            ),
+        )
+        assert link.follow_up is not None
+        assert link.follow_up.text == "Anything else?"
+        assert link.follow_up.reply_markup is not None
+        rows = link.follow_up.reply_markup.inline_keyboard
+        assert len(rows) == 1
+        callbacks = sorted(btn.callback_data for btn in rows[0])
+        assert callbacks == ["bet", "menu"]
+
+    def test_follow_up_serializes_and_round_trips(self):
+        """``model_dump`` preserves follow_up so DynamoDB persistence
+        and BO round-tripping work end-to-end."""
+        original = LinkItem(
+            title="Support",
+            message_text="Need help?",
+            button_label="Contact Support",
+            button_url="https://example.com/support",
+            follow_up=MessageItem(text="See you soon!"),
+        )
+        dumped = original.model_dump()
+        assert dumped["follow_up"]["text"] == "See you soon!"
+        assert dumped["follow_up"].get("reply_markup") is None
+        rebuilt = LinkItem.model_validate(dumped)
+        assert rebuilt == original
+
 
 class TestLinksMessages:
     """Test links messages container"""


### PR DESCRIPTION
## Summary

Promotes the only commit on `develop` not yet on `staging`:

- `bf10967` — `feat(86ah4m4zy): add LinkItem.follow_up for operator-managed post-link messages` (originally [PR #133](https://github.com/AIChatBet/chatbet-base-models/pull/133))

## Context

[CU-86ah4m4zy](https://app.clickup.com/t/86ah4m4zy). Adds the optional `follow_up: Optional[MessageItem] = None` field on `LinkItem`. Default `None` — backward compatible. Required by:

- bet-bot staging promotion ([PR pending](https://github.com/AIChatBet/chatbet-channel-services/pulls)) — `handle_redirection_intent` consumes `link_item.follow_up`.
- chatbet-backoffice staging promotion ([PR pending](https://github.com/AIChatBet/chatbet-backoffice/pulls)) — frontend editor for the new field.

bet-bot and chatbet-backoffice both pip-install this package via `git+...@staging` in their staging Docker builds, so this PR has to merge first.

## Test plan

- [x] 99 → 102 tests pass on the develop branch.
- [ ] Smoke after merge: confirm `chatbet-base-models@staging` carries `LinkItem.follow_up` (e.g. `pip show chatbet-base-models` in a staging container).