### PR TITLE
feat: add markets_back_options/markets_more_options to LabelMessages

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -550,9 +550,11 @@ class LabelMessages(BaseModel):
     sports_more_options: Optional[MessageItem] = None
     tournaments_more_options: Optional[MessageItem] = None
     matches_more_options: Optional[MessageItem] = None
+    markets_more_options: Optional[MessageItem] = None
     sports_back_options: Optional[MessageItem] = None
     tournaments_back_options: Optional[MessageItem] = None
     matches_back_options: Optional[MessageItem] = None
+    markets_back_options: Optional[MessageItem] = None
     edit_bet_label_text: Optional[MessageItem] = None
     back_option: Optional[MessageItem] = None
     home_page_text: Optional[MessageItem] = None
@@ -1259,9 +1261,11 @@ class MessageTemplates(BaseModel):
                 sports_more_options=MessageItem(text="More sports >>"),
                 tournaments_more_options=MessageItem(text="More tournaments >>"),
                 matches_more_options=MessageItem(text="More matches >>"),
+                markets_more_options=MessageItem(text="Siguiente →"),
                 sports_back_options=MessageItem(text="<< Prev sports"),
                 tournaments_back_options=MessageItem(text="<< Prev tournaments"),
                 matches_back_options=MessageItem(text="<< Prev matches"),
+                markets_back_options=MessageItem(text="← Anterior"),
                 edit_bet_label_text=MessageItem(text="Edit bet"),
                 back_option=MessageItem(text="<< Back"),
                 home_page_text=MessageItem(text="Go to website \U0001f310"),

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1563,3 +1563,35 @@ class TestLabelMessagesNewFields:
         assert labels.more_options_label.text == "More options"
         assert labels.account_locked_text.text == "Account locked"
         assert labels.invalid_otp_text.text == "Invalid OTP"
+
+
+class TestLabelMessagesMarketPaginationFields:
+    """Tests for market-pagination label fields used by the WhatsApp adapter.
+
+    These keys are consumed by ``bet-bot``'s WhatsApp market pagination so the
+    "options inside a market" screens (over/under, spread, ...) ship copy that
+    matches the screen context — distinct from the FIXTURE pagination labels
+    (``matches_back_options`` / ``matches_more_options``).
+    """
+
+    MARKET_FIELDS = ("markets_back_options", "markets_more_options")
+
+    def test_market_fields_accept_message_item(self):
+        for field_name in self.MARKET_FIELDS:
+            labels = LabelMessages(**{field_name: MessageItem(text="custom")})
+            value = getattr(labels, field_name)
+            assert value is not None
+            assert value.text == "custom"
+
+    def test_market_fields_default_to_none(self):
+        labels = LabelMessages()
+        for field_name in self.MARKET_FIELDS:
+            assert getattr(labels, field_name) is None
+
+    def test_market_fields_present_in_from_minimal(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.labels is not None
+        assert templates.labels.markets_back_options is not None
+        assert templates.labels.markets_more_options is not None
+        assert templates.labels.markets_back_options.text
+        assert templates.labels.markets_more_options.text


### PR DESCRIPTION
## Summary

Adds two optional `MessageItem` fields to `LabelMessages` so operators can configure custom button labels for market-options pagination on WhatsApp (over/under, spread, etc.).

- `markets_back_options` — "previous page" button
- `markets_more_options` — "next page" button

Mirrors the existing `matches_back_options` / `matches_more_options` pattern used by fixture pagination. Defaults populated in `from_minimal()` so factory-built templates expose the new labels.

## Why

Required by **bet-bot CU-86ahm471b** (WhatsApp market pagination). WhatsApp list sections cap at 10 rows; the bot now paginates with 8 options + up to 2 nav rows per page. The adapter reads `markets_back_options` / `markets_more_options` from `LabelMessages` to render the nav buttons with operator-configured copy, falling back to `← Anterior` / `Siguiente →` when not set.

**Order matters:** this PR must merge BEFORE the bet-bot PR or bet-bot CI will fail (Dockerfile installs chatbet-base-models from this branch via `pip install git+...@develop`).

## Test plan

- [x] `tests/test_message_template.py::TestLabelMessagesMarketPaginationFields` — 3 new tests confirming the fields accept `MessageItem`, default to `None`, and are populated by `from_minimal()`.
- [ ] CI passes (Python 3.10-3.12, 80% coverage threshold).
- [ ] Verify no downstream services break (sportbook_services, broadcast, backoffice consume this lib).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced market navigation labels enabling pagination through markets with "Next" and "Previous" controls.

* **Tests**
  - Added test suite verifying new market pagination label fields initialize and function correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIChatBet/chatbet-base-models/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->