### PR TITLE
feat: add markets_back_options/markets_more_options to LabelMessages (staging backport)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -542,9 +542,11 @@ class LabelMessages(BaseModel):
     sports_more_options: Optional[MessageItem] = None
     tournaments_more_options: Optional[MessageItem] = None
     matches_more_options: Optional[MessageItem] = None
+    markets_more_options: Optional[MessageItem] = None
     sports_back_options: Optional[MessageItem] = None
     tournaments_back_options: Optional[MessageItem] = None
     matches_back_options: Optional[MessageItem] = None
+    markets_back_options: Optional[MessageItem] = None
     edit_bet_label_text: Optional[MessageItem] = None
     back_option: Optional[MessageItem] = None
     home_page_text: Optional[MessageItem] = None
@@ -1233,9 +1235,11 @@ class MessageTemplates(BaseModel):
                 sports_more_options=MessageItem(text="More sports >>"),
                 tournaments_more_options=MessageItem(text="More tournaments >>"),
                 matches_more_options=MessageItem(text="More matches >>"),
+                markets_more_options=MessageItem(text="Siguiente →"),
                 sports_back_options=MessageItem(text="<< Prev sports"),
                 tournaments_back_options=MessageItem(text="<< Prev tournaments"),
                 matches_back_options=MessageItem(text="<< Prev matches"),
+                markets_back_options=MessageItem(text="← Anterior"),
                 edit_bet_label_text=MessageItem(text="Edit bet"),
                 back_option=MessageItem(text="<< Back"),
                 home_page_text=MessageItem(text="Go to website \U0001f310"),

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1464,3 +1464,35 @@ class TestLabelMessagesNewFields:
         assert labels.more_options_label.text == "More options"
         assert labels.account_locked_text.text == "Account locked"
         assert labels.invalid_otp_text.text == "Invalid OTP"
+
+
+class TestLabelMessagesMarketPaginationFields:
+    """Tests for market-pagination label fields used by the WhatsApp adapter.
+
+    These keys are consumed by ``bet-bot``'s WhatsApp market pagination so the
+    "options inside a market" screens (over/under, spread, ...) ship copy that
+    matches the screen context — distinct from the FIXTURE pagination labels
+    (``matches_back_options`` / ``matches_more_options``).
+    """
+
+    MARKET_FIELDS = ("markets_back_options", "markets_more_options")
+
+    def test_market_fields_accept_message_item(self):
+        for field_name in self.MARKET_FIELDS:
+            labels = LabelMessages(**{field_name: MessageItem(text="custom")})
+            value = getattr(labels, field_name)
+            assert value is not None
+            assert value.text == "custom"
+
+    def test_market_fields_default_to_none(self):
+        labels = LabelMessages()
+        for field_name in self.MARKET_FIELDS:
+            assert getattr(labels, field_name) is None
+
+    def test_market_fields_present_in_from_minimal(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.labels is not None
+        assert templates.labels.markets_back_options is not None
+        assert templates.labels.markets_more_options is not None
+        assert templates.labels.markets_back_options.text
+        assert templates.labels.markets_more_options.text


### PR DESCRIPTION
## Summary

Backport of #139 to `staging`. Cherry-pick of commit `05f1d73`.

Adds two optional `MessageItem` fields to `LabelMessages` (`markets_back_options`, `markets_more_options`) used by the WhatsApp/Whapi market pagination feature in bet-bot.

## Why backport now

Needed on `staging` so the parallel bet-bot staging PR can have CI pass (Dockerfile installs chatbet-base-models from `@staging` for the staging deploy).

## Test plan

- [x] Cherry-pick auto-merged cleanly from develop (#139, merge `c5eb968`).
- [ ] CI passes (Python 3.10-3.12, 80% coverage threshold).

Refs: #139, AIChatBet/chatbet-channel-services CU-86ahm471b