### PR TITLE
feat(registration): add account_not_found template for platform-unknown UX

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -239,6 +239,7 @@ class RegistrationMessages(BaseModel):
     model_config = ConfigDict(extra="forbid")
     not_registered_user: Optional[MessageItem] = None
     not_registered_user_country: Optional[MessageItem] = None
+    account_not_found: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -976,6 +977,9 @@ class MessageTemplates(BaseModel):
                 not_registered_user=MessageItem(text="You are not registered."),
                 not_registered_user_country=MessageItem(
                     text="You are in the wrong country."
+                ),
+                account_not_found=MessageItem(
+                    text="We couldn't find an account with that information. Would you like to create a new one?"
                 ),
             ),
             menu=MenuMessages(

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -9,6 +9,7 @@ from chatbet_base_models.message_template import (
     LabelMessages,
     MessageItem,
     OnboardingMessages,
+    RegistrationMessages,
     ValidationMessages,
     MenuMessages,
     BetsMessages,
@@ -257,6 +258,58 @@ class TestValidationMessagesPasswordTemplates:
             assert item["validation"][key]["text"], (
                 f"{key} must have non-empty text in DynamoDB serialization"
             )
+
+
+class TestRegistrationMessages:
+    def test_create_registration_messages_with_all_fields(self):
+        registration = RegistrationMessages(
+            not_registered_user=MessageItem(text="You are not registered."),
+            not_registered_user_country=MessageItem(
+                text="You are in the wrong country."
+            ),
+            account_not_found=MessageItem(
+                text="We couldn't find an account with that information."
+            ),
+        )
+        assert registration.not_registered_user.text == "You are not registered."
+        assert (
+            registration.not_registered_user_country.text
+            == "You are in the wrong country."
+        )
+        assert (
+            registration.account_not_found.text
+            == "We couldn't find an account with that information."
+        )
+
+    def test_account_not_found_defaults_to_none(self):
+        registration = RegistrationMessages()
+        assert registration.account_not_found is None
+
+    def test_extra_keys_are_forbidden(self):
+        with pytest.raises(ValidationError):
+            RegistrationMessages(unknown_field=MessageItem(text="x"))
+
+    def test_from_minimal_seeds_account_not_found(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.registration.account_not_found is not None
+        assert templates.registration.account_not_found.text == (
+            "We couldn't find an account with that information. "
+            "Would you like to create a new one?"
+        )
+
+    def test_round_trip_through_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "registration" in item
+        assert "account_not_found" in item["registration"]
+        assert item["registration"]["account_not_found"]["text"]
+
+        restored = MessageTemplates(**item)
+        assert restored.registration.account_not_found is not None
+        assert (
+            restored.registration.account_not_found.text
+            == templates.registration.account_not_found.text
+        )
 
 
 class TestMenuMessages:


### PR DESCRIPTION
## Summary

- Adds `Optional[MessageItem] account_not_found` field to `RegistrationMessages` (`message_template.py:~241`).
- Adds a default seed for the new field inside `from_minimal()` (`message_template.py:~980`).
- Adds a `TestRegistrationMessages` test class covering: all-fields construction, default `None`, `extra="forbid"` enforcement, `from_minimal()` seed, and `to_dynamodb_item()` round-trip.

## Why

The downstream consumer `bet-bot` currently reuses the same `not_registered_user` template across two semantically distinct UX paths:

1. User clicks "No, I don't have an account" — legitimate path.
2. User says "Yes I have an account", provides phone, platform doesn't recognize them — confusing UX (the message reads as if the bot called the user a liar).

Splitting requires a new template key here. Bet-bot will introduce the matching action `"account_not_found"` and route paths (2) to it, while path (1) keeps using `not_registered_user`. Operators can override the new key per tenant via the backoffice / DynamoDB; until then, a permanent OR-fallback in bet-bot keeps the UX from breaking.

## Cross-repo coordination

- Merge order: this PR MUST merge to `develop` BEFORE the corresponding bet-bot PR opens, because bet-bot installs this package via `pip install git+...@develop` at build time (Dockerfile:14).
- Same ordering rule applies for `develop -> staging` and `staging -> main` promotions.
- See SDD change `split-not-registered-template` for full context (specs, design, tasks).

## Test plan

- [x] CI passes (Python 3.10-3.12, 80% coverage). Local: 347 passed, coverage 91.98%.
- [x] `from_minimal()` returns the new field populated with default copy.
- [x] `to_dynamodb_item()` round-trip preserves the new field.
- [x] `RegistrationMessages()` with no args defaults `account_not_found` to `None`.
- [x] Unknown keys still rejected (`extra="forbid"` regression covered).
- [x] Existing consumers using `not_registered_user` are unaffected (additive change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new message template for registration flows that appears when an account is not found, prompting users to create a new account.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIChatBet/chatbet-base-models/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->