### PR TITLE
feat(site_config): add optional fixture_range_days to FeaturesConfig

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -349,6 +349,17 @@ class FeaturesConfig(BaseModel):
         default=False,
         description="Enable or disable live in this configuration",
     )
+    fixture_range_days: Optional[int] = Field(
+        default=7,
+        ge=1,
+        le=365,
+        description=(
+            "Window in days for DynamoDB fixture listing queries. "
+            "Wider values let long-horizon tournaments (e.g. World Cup) "
+            "surface earlier; narrower values keep result sets smaller. "
+            "Default 7 preserves legacy behavior."
+        ),
+    )
 
 
 class Meta(BaseModel):
@@ -422,6 +433,7 @@ class SiteConfig(BaseModel):
             hour_format=HourFormat.H24,
             skip_pre_auth_validation=False,
             live=False,
+            fixture_range_days=7,
         )
     )
     limits: MoneyLimits = Field(

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -459,6 +459,44 @@ class TestFeaturesConfig:
         )
         assert features_momio.alias_probabilities == AliasProbabilities.MOMIO
 
+    def test_features_config_default_fixture_range_days(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+        )
+        assert features.fixture_range_days == 7
+
+    def test_features_config_custom_fixture_range_days(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+            fixture_range_days=30,
+        )
+        assert features.fixture_range_days == 30
+
+    def test_features_config_invalid_fixture_range_days(self):
+        from pydantic import ValidationError
+
+        for invalid in (0, -1, 366, 1000):
+            with pytest.raises(ValidationError):
+                FeaturesConfig(
+                    odd_type=OddType.DECIMAL,
+                    validation=ValidationMethod.EMAIL,
+                    combos=True,
+                    chatbet_version=ChatbetVersion.V2,
+                    multigames_response=True,
+                    see_in_combo=True,
+                    fixture_range_days=invalid,
+                )
+
 
 class TestMeta:
     def test_create_meta_with_defaults(self):


### PR DESCRIPTION
## Summary

Adds a per-company override for the DynamoDB fixture-listing date window in `FeaturesConfig` (default 7 days). Wider values let long-horizon tournaments (e.g. FIFA World Cup) surface earlier; narrower values keep listing payloads small.

## Changes

- New field `fixture_range_days: Optional[int] = Field(default=7, ge=1, le=365)` in `FeaturesConfig`
- `SiteConfig.features` default_factory updated to include the field explicitly
- 3 new tests in `TestFeaturesConfig`: default value, custom override, invalid bounds

## Backwards compatibility

The field is **Optional with default 7**. Companies whose stored `site_config` doesn't include it keep the legacy 7-day behavior unchanged. Pydantic materializes the default on load.

## Test plan

- [x] `pytest tests/test_site_config_model.py::TestFeaturesConfig -v` → 6/6 passing
- [x] No regressions on existing tests
- [ ] Merge first — downstream PRs (sportbook_services + chatbet-backoffice) depend on this field existing in the model

## Related PRs

- sportbook_services: https://github.com/AIChatBet/chatbet-sportbook-services/pull/new/feat/configurable-fixture-range
- chatbet-backoffice: https://github.com/AIChatBet/chatbet-backoffice/pull/new/feat/fixture-range-days-field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable fixture range setting (1-365 days, default 7) to control fixture lookup windows.

* **Tests**
  * Added validation tests for the new fixture range setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIChatBet/chatbet-base-models/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->