### PR TITLE
feat(combos): add min_legs_warning message template (CU-86ahjuant)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -342,6 +342,7 @@ class CombosMessages(BaseModel):
     combos_confirm_add_recommended: Optional[MessageItem] = None
     delete_bet_from_combo: Optional[MessageItem] = None
     replace_bet_from_combo: Optional[MessageItem] = None
+    min_legs_warning: Optional[MessageItem] = None
     combo_not_allowed_not_combinable: Optional[MessageItem] = MessageItem(
         text="This combo cannot be combined with other offers."
     )
@@ -1217,6 +1218,9 @@ class MessageTemplates(BaseModel):
                             ]
                         ]
                     ),
+                ),
+                min_legs_warning=MessageItem(
+                    text="⚠️ A parlay needs at least {MIN_LEGS} selections. Add another selection to continue."
                 ),
             ),
             errors=ErrorMessages(


### PR DESCRIPTION
## What
Adds a new `min_legs_warning` message template key to `CombosMessages`, with an English default in `from_minimal()`.

## Why
Part of the fix for [CU-86ahjuant](https://app.clickup.com/t/86ahjuant): single-leg parlays were placed and reported as successful combos while ORO created a straight bet. The bet-bot guard now blocks them and shows a warning. That warning must be a templatable, company-customizable message (multi-tenant convention) instead of hardcoded inline text — Spanish-configured companies (e.g. plannatech) need it in their own language.

## Change
- `CombosMessages.min_legs_warning: Optional[MessageItem] = None`
- Default in `MessageTemplates.from_minimal()`: "⚠️ A parlay needs at least {MIN_LEGS} selections. Add another selection to continue."

Purely additive and backward-compatible.

## Deploy order
**This must merge to `develop` BEFORE the bet-bot PR.** `CombosMessages` uses `extra="forbid"`; a company config carrying the new key against a base-models version lacking the field would fail Pydantic parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a minimum legs warning message for parlay bets, notifying users of the minimum number of selections required before placing a bet.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIChatBet/chatbet-base-models/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->