### PR TITLE
feat(combos): add min_legs_warning message template (CU-86ahjuant) [staging]

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -342,6 +342,7 @@ class CombosMessages(BaseModel):
     combos_confirm_add_recommended: Optional[MessageItem] = None
     delete_bet_from_combo: Optional[MessageItem] = None
     replace_bet_from_combo: Optional[MessageItem] = None
+    min_legs_warning: Optional[MessageItem] = None
     combo_not_allowed_not_combinable: Optional[MessageItem] = MessageItem(
         text="This combo cannot be combined with other offers."
     )
@@ -1217,6 +1218,9 @@ class MessageTemplates(BaseModel):
                             ]
                         ]
                     ),
+                ),
+                min_legs_warning=MessageItem(
+                    text="⚠️ A parlay needs at least {MIN_LEGS} selections. Add another selection to continue."
                 ),
             ),
             errors=ErrorMessages(


### PR DESCRIPTION
Promotes the `min_legs_warning` `CombosMessages` field to **staging** (already merged to develop in #145). Part of [CU-86ahjuant](https://app.clickup.com/t/86ahjuant).

Purely additive / backward-compatible. **Merge this to staging BEFORE the bet-bot and backoffice staging PRs** — `CombosMessages` uses `extra="forbid"`, so consumers must run a base-models version with the field before any staging DynamoDB config carries the key.