### PR TITLE
feat: add auth, fixture_range_days and combos.min_legs_warning config fields

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -336,6 +336,7 @@ class CombosMessages(BaseModel):
     combo_not_allowed_not_combinable: Optional[MessageItem] = MessageItem(
         text="This combo cannot be combined with other offers."
     )
+    min_legs_warning: Optional[MessageItem] = None
 
     @field_validator("combos_recommendation")
     @classmethod

--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -349,6 +349,17 @@ class FeaturesConfig(BaseModel):
         default=False,
         description="Enable or disable live in this configuration",
     )
+    fixture_range_days: Optional[int] = Field(
+        default=None,
+        description="Number of days ahead to fetch fixtures",
+    )
+
+
+class AuthConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    method: Optional[str] = Field(default=None, description="Auth method, e.g. 'otp' or 'password'")
+    flow_id: Optional[str] = None
+    forgot_password_url: Optional[str] = None
 
 
 class Meta(BaseModel):
@@ -430,6 +441,9 @@ class SiteConfig(BaseModel):
     )
     api_key: Optional[str] = Field(
         default=None, description="API key for public endpoints"
+    )
+    auth: Optional[AuthConfig] = Field(
+        default=None, description="Authentication flow configuration"
     )
 
     @classmethod


### PR DESCRIPTION
## Context
Deployed company configs in DynamoDB already carry three fields the pydantic models did not declare. Because the config models use `extra="forbid"`, validation failed at runtime for **plannatech, chatbeten, bolabet and betvip** (e.g. `SiteConfig.auth`, `features.fixture_range_days`, `combos.min_legs_warning` "Extra inputs are not permitted").

## Changes
- `SiteConfig.auth` — new `AuthConfig` submodel (`method`, `flow_id`, `forgot_password_url`)
- `FeaturesConfig.fixture_range_days: Optional[int]`
- `CombosMessages.min_legs_warning: Optional[MessageItem]`

All fields are `Optional` with defaults → backward compatible (companies without them keep validating).

## Testing
- All 4 company configs (betvip/chatbeten/plannatech/bolabet) now validate.
- Full base-models suite: **319 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for minimum legs warning messages in combo selections
  * Introduced fixture range days parameter for customizable date-range settings
  * Added authentication configuration options including authentication method, flow ID, and password recovery URL setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIChatBet/chatbet-base-models/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->