### PR TITLE
release: 2026-05-27 staging→main

### DIFF
--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -72,6 +72,7 @@ from .site_config_model import (
     LocaleConfig,
     FeaturesConfig,
     Meta,
+    AuthConfig,
     SiteConfig,
     SiteConfigDB,
 )
@@ -171,6 +172,7 @@ __all__ = [
     "LocaleConfig",
     "FeaturesConfig",
     "Meta",
+    "AuthConfig",
     "SiteConfig",
     "SiteConfigDB",
     # Sportbook Configuration

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -342,6 +342,7 @@ class CombosMessages(BaseModel):
     combos_confirm_add_recommended: Optional[MessageItem] = None
     delete_bet_from_combo: Optional[MessageItem] = None
     replace_bet_from_combo: Optional[MessageItem] = None
+    min_legs_warning: Optional[MessageItem] = None
     combo_not_allowed_not_combinable: Optional[MessageItem] = MessageItem(
         text="This combo cannot be combined with other offers."
     )
@@ -1217,6 +1218,9 @@ class MessageTemplates(BaseModel):
                             ]
                         ]
                     ),
+                ),
+                min_legs_warning=MessageItem(
+                    text="⚠️ A parlay needs at least {MIN_LEGS} selections. Add another selection to continue."
                 ),
             ),
             errors=ErrorMessages(

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -188,6 +188,14 @@ class ValidationMessages(BaseModel):
     error_otp: Optional[MessageItem] = None
     blocked_otp: Optional[MessageItem] = None
     blocked_user: Optional[MessageItem] = None
+    # Password-auth POC templates (sibling to OTP templates).
+    # See SDD change `password-auth-poc`.
+    password_required: Optional[MessageItem] = None
+    password_form_invalid: Optional[MessageItem] = None
+    password_failed: Optional[MessageItem] = None
+    password_already_registered: Optional[MessageItem] = None
+    password_ok_register: Optional[MessageItem] = None
+    password_ok_login: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -942,6 +950,24 @@ class MessageTemplates(BaseModel):
                 ),
                 blocked_user=MessageItem(
                     text="Sorry, I can't help you, you are blocked",
+                ),
+                password_required=MessageItem(
+                    text="Para continuar, completá el formulario rápido 👇",
+                ),
+                password_form_invalid=MessageItem(
+                    text="Faltan datos en el formulario. Volvé a intentar.",
+                ),
+                password_failed=MessageItem(
+                    text="No pudimos validar tus datos. Verificá e intentá de nuevo.",
+                ),
+                password_already_registered=MessageItem(
+                    text="Esta cuenta ya está registrada. Iniciá sesión.",
+                ),
+                password_ok_register=MessageItem(
+                    text="✅ ¡Cuenta creada!",
+                ),
+                password_ok_login=MessageItem(
+                    text="✅ ¡Sesión iniciada!",
                 ),
             ),
             registration=RegistrationMessages(

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -239,6 +239,7 @@ class RegistrationMessages(BaseModel):
     model_config = ConfigDict(extra="forbid")
     not_registered_user: Optional[MessageItem] = None
     not_registered_user_country: Optional[MessageItem] = None
+    account_not_found: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -976,6 +977,9 @@ class MessageTemplates(BaseModel):
                 not_registered_user=MessageItem(text="You are not registered."),
                 not_registered_user_country=MessageItem(
                     text="You are in the wrong country."
+                ),
+                account_not_found=MessageItem(
+                    text="We couldn't find an account with that information. Would you like to create a new one?"
                 ),
             ),
             menu=MenuMessages(

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -550,9 +550,11 @@ class LabelMessages(BaseModel):
     sports_more_options: Optional[MessageItem] = None
     tournaments_more_options: Optional[MessageItem] = None
     matches_more_options: Optional[MessageItem] = None
+    markets_more_options: Optional[MessageItem] = None
     sports_back_options: Optional[MessageItem] = None
     tournaments_back_options: Optional[MessageItem] = None
     matches_back_options: Optional[MessageItem] = None
+    markets_back_options: Optional[MessageItem] = None
     edit_bet_label_text: Optional[MessageItem] = None
     back_option: Optional[MessageItem] = None
     home_page_text: Optional[MessageItem] = None
@@ -1259,9 +1261,11 @@ class MessageTemplates(BaseModel):
                 sports_more_options=MessageItem(text="More sports >>"),
                 tournaments_more_options=MessageItem(text="More tournaments >>"),
                 matches_more_options=MessageItem(text="More matches >>"),
+                markets_more_options=MessageItem(text="Siguiente →"),
                 sports_back_options=MessageItem(text="<< Prev sports"),
                 tournaments_back_options=MessageItem(text="<< Prev tournaments"),
                 matches_back_options=MessageItem(text="<< Prev matches"),
+                markets_back_options=MessageItem(text="← Anterior"),
                 edit_bet_label_text=MessageItem(text="Edit bet"),
                 back_option=MessageItem(text="<< Back"),
                 home_page_text=MessageItem(text="Go to website \U0001f310"),

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -542,9 +542,11 @@ class LabelMessages(BaseModel):
     sports_more_options: Optional[MessageItem] = None
     tournaments_more_options: Optional[MessageItem] = None
     matches_more_options: Optional[MessageItem] = None
+    markets_more_options: Optional[MessageItem] = None
     sports_back_options: Optional[MessageItem] = None
     tournaments_back_options: Optional[MessageItem] = None
     matches_back_options: Optional[MessageItem] = None
+    markets_back_options: Optional[MessageItem] = None
     edit_bet_label_text: Optional[MessageItem] = None
     back_option: Optional[MessageItem] = None
     home_page_text: Optional[MessageItem] = None
@@ -1233,9 +1235,11 @@ class MessageTemplates(BaseModel):
                 sports_more_options=MessageItem(text="More sports >>"),
                 tournaments_more_options=MessageItem(text="More tournaments >>"),
                 matches_more_options=MessageItem(text="More matches >>"),
+                markets_more_options=MessageItem(text="Siguiente →"),
                 sports_back_options=MessageItem(text="<< Prev sports"),
                 tournaments_back_options=MessageItem(text="<< Prev tournaments"),
                 matches_back_options=MessageItem(text="<< Prev matches"),
+                markets_back_options=MessageItem(text="← Anterior"),
                 edit_bet_label_text=MessageItem(text="Edit bet"),
                 back_option=MessageItem(text="<< Back"),
                 home_page_text=MessageItem(text="Go to website \U0001f310"),

--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -349,6 +349,17 @@ class FeaturesConfig(BaseModel):
         default=False,
         description="Enable or disable live in this configuration",
     )
+    fixture_range_days: Optional[int] = Field(
+        default=7,
+        ge=1,
+        le=365,
+        description=(
+            "Window in days for DynamoDB fixture listing queries. "
+            "Wider values let long-horizon tournaments (e.g. World Cup) "
+            "surface earlier; narrower values keep result sets smaller. "
+            "Default 7 preserves legacy behavior."
+        ),
+    )
 
 
 class Meta(BaseModel):
@@ -422,6 +433,7 @@ class SiteConfig(BaseModel):
             hour_format=HourFormat.H24,
             skip_pre_auth_validation=False,
             live=False,
+            fixture_range_days=7,
         )
     )
     limits: MoneyLimits = Field(

--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -359,6 +359,37 @@ class Meta(BaseModel):
 
 
 # ==========================="
+# Auth Config
+# ==========================="
+
+
+class AuthConfig(BaseModel):
+    """Operator-level authentication configuration.
+
+    Defaults to OTP for backward compatibility with existing operators.
+    When ``method == "password"``, ``flow_id`` is required and the
+    operator's WhatsApp provider must be ``meta`` (Cloud API). The
+    provider compatibility check lives on ``SiteConfig`` because it
+    needs access to the sibling ``integrations`` block.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    method: Literal["otp", "password"] = Field(
+        default="otp",
+        description="Auth method: 'otp' (legacy default) or 'password' (WhatsApp Flow form)",
+    )
+    flow_id: str | None = Field(
+        default=None,
+        description="Meta WhatsApp Flow ID (required when method='password')",
+    )
+    forgot_password_url: HttpUrl | None = Field(
+        default=None,
+        description="Optional forgot-password URL — reserved for Phase 2 (deferred).",
+    )
+
+
+# ==========================="
 # General Config (no core wrapper)
 # ==========================="
 
@@ -431,6 +462,48 @@ class SiteConfig(BaseModel):
     api_key: Optional[str] = Field(
         default=None, description="API key for public endpoints"
     )
+    auth: AuthConfig = Field(
+        default_factory=AuthConfig,
+        description=(
+            "Operator-level auth configuration. Default factory ⇒ method='otp' so "
+            "operators without an explicit auth block keep the legacy OTP path."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_auth_compatibility(self) -> "SiteConfig":
+        """Cross-field validation between ``auth`` and ``integrations``.
+
+        Two rules:
+        1. ``auth.method == 'password'`` requires ``auth.flow_id`` to be set
+           (Meta WhatsApp Flows cannot be sent without a published flow id).
+        2. ``auth.method == 'password'`` is incompatible with WhatsApp
+           provider ``whapi`` — Flow messages (``interactive.type='flow'``)
+           require Cloud API (``provider='meta'``). Skipped when no
+           WhatsApp integration is configured at all.
+        """
+        if self.auth.method != "password":
+            return self
+
+        if self.auth.flow_id is None:
+            raise ValueError(
+                "auth.method='password' requires auth.flow_id to be set"
+            )
+
+        whatsapp = self.integrations.whatsapp if self.integrations else None
+        if whatsapp is None:
+            # No WhatsApp configured — nothing to validate against.
+            return self
+
+        provider = getattr(whatsapp.config, "provider", None)
+        if provider == "whapi":
+            raise ValueError(
+                "auth.method='password' is incompatible with WhatsApp "
+                "provider 'whapi' — Flows require WhatsApp Cloud API "
+                "(provider='meta')"
+            )
+
+        return self
 
     @classmethod
     def default_factory(cls, site_name: str, company_id: str) -> SiteConfig:

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1464,3 +1464,35 @@ class TestLabelMessagesNewFields:
         assert labels.more_options_label.text == "More options"
         assert labels.account_locked_text.text == "Account locked"
         assert labels.invalid_otp_text.text == "Invalid OTP"
+
+
+class TestLabelMessagesMarketPaginationFields:
+    """Tests for market-pagination label fields used by the WhatsApp adapter.
+
+    These keys are consumed by ``bet-bot``'s WhatsApp market pagination so the
+    "options inside a market" screens (over/under, spread, ...) ship copy that
+    matches the screen context — distinct from the FIXTURE pagination labels
+    (``matches_back_options`` / ``matches_more_options``).
+    """
+
+    MARKET_FIELDS = ("markets_back_options", "markets_more_options")
+
+    def test_market_fields_accept_message_item(self):
+        for field_name in self.MARKET_FIELDS:
+            labels = LabelMessages(**{field_name: MessageItem(text="custom")})
+            value = getattr(labels, field_name)
+            assert value is not None
+            assert value.text == "custom"
+
+    def test_market_fields_default_to_none(self):
+        labels = LabelMessages()
+        for field_name in self.MARKET_FIELDS:
+            assert getattr(labels, field_name) is None
+
+    def test_market_fields_present_in_from_minimal(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.labels is not None
+        assert templates.labels.markets_back_options is not None
+        assert templates.labels.markets_more_options is not None
+        assert templates.labels.markets_back_options.text
+        assert templates.labels.markets_more_options.text

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -9,6 +9,7 @@ from chatbet_base_models.message_template import (
     LabelMessages,
     MessageItem,
     OnboardingMessages,
+    RegistrationMessages,
     ValidationMessages,
     MenuMessages,
     BetsMessages,
@@ -257,6 +258,58 @@ class TestValidationMessagesPasswordTemplates:
             assert item["validation"][key]["text"], (
                 f"{key} must have non-empty text in DynamoDB serialization"
             )
+
+
+class TestRegistrationMessages:
+    def test_create_registration_messages_with_all_fields(self):
+        registration = RegistrationMessages(
+            not_registered_user=MessageItem(text="You are not registered."),
+            not_registered_user_country=MessageItem(
+                text="You are in the wrong country."
+            ),
+            account_not_found=MessageItem(
+                text="We couldn't find an account with that information."
+            ),
+        )
+        assert registration.not_registered_user.text == "You are not registered."
+        assert (
+            registration.not_registered_user_country.text
+            == "You are in the wrong country."
+        )
+        assert (
+            registration.account_not_found.text
+            == "We couldn't find an account with that information."
+        )
+
+    def test_account_not_found_defaults_to_none(self):
+        registration = RegistrationMessages()
+        assert registration.account_not_found is None
+
+    def test_extra_keys_are_forbidden(self):
+        with pytest.raises(ValidationError):
+            RegistrationMessages(unknown_field=MessageItem(text="x"))
+
+    def test_from_minimal_seeds_account_not_found(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.registration.account_not_found is not None
+        assert templates.registration.account_not_found.text == (
+            "We couldn't find an account with that information. "
+            "Would you like to create a new one?"
+        )
+
+    def test_round_trip_through_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "registration" in item
+        assert "account_not_found" in item["registration"]
+        assert item["registration"]["account_not_found"]["text"]
+
+        restored = MessageTemplates(**item)
+        assert restored.registration.account_not_found is not None
+        assert (
+            restored.registration.account_not_found.text
+            == templates.registration.account_not_found.text
+        )
 
 
 class TestMenuMessages:

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1563,3 +1563,35 @@ class TestLabelMessagesNewFields:
         assert labels.more_options_label.text == "More options"
         assert labels.account_locked_text.text == "Account locked"
         assert labels.invalid_otp_text.text == "Invalid OTP"
+
+
+class TestLabelMessagesMarketPaginationFields:
+    """Tests for market-pagination label fields used by the WhatsApp adapter.
+
+    These keys are consumed by ``bet-bot``'s WhatsApp market pagination so the
+    "options inside a market" screens (over/under, spread, ...) ship copy that
+    matches the screen context — distinct from the FIXTURE pagination labels
+    (``matches_back_options`` / ``matches_more_options``).
+    """
+
+    MARKET_FIELDS = ("markets_back_options", "markets_more_options")
+
+    def test_market_fields_accept_message_item(self):
+        for field_name in self.MARKET_FIELDS:
+            labels = LabelMessages(**{field_name: MessageItem(text="custom")})
+            value = getattr(labels, field_name)
+            assert value is not None
+            assert value.text == "custom"
+
+    def test_market_fields_default_to_none(self):
+        labels = LabelMessages()
+        for field_name in self.MARKET_FIELDS:
+            assert getattr(labels, field_name) is None
+
+    def test_market_fields_present_in_from_minimal(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.labels is not None
+        assert templates.labels.markets_back_options is not None
+        assert templates.labels.markets_more_options is not None
+        assert templates.labels.markets_back_options.text
+        assert templates.labels.markets_more_options.text

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -160,6 +160,105 @@ class TestValidationMessages:
         assert validation.send_otp.text == "OTP sent"
 
 
+# Password-auth POC templates — keys live under `validation.*` alongside OTP
+# templates (sibling auth namespace). See SDD change `password-auth-poc`.
+PASSWORD_TEMPLATE_KEYS = (
+    "password_required",
+    "password_form_invalid",
+    "password_failed",
+    "password_already_registered",
+    "password_ok_register",
+    "password_ok_login",
+)
+
+
+class TestValidationMessagesPasswordTemplates:
+    """Validate the password-auth POC templates added under ValidationMessages."""
+
+    def test_password_templates_default_to_none_on_bare_validation_messages(self):
+        validation = ValidationMessages()
+        for key in PASSWORD_TEMPLATE_KEYS:
+            assert getattr(validation, key) is None, (
+                f"{key} must default to None when not provided"
+            )
+
+    def test_from_minimal_provides_password_template_defaults(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.validation is not None
+        assert (
+            templates.validation.password_required.text
+            == "Para continuar, completá el formulario rápido 👇"
+        )
+        assert (
+            templates.validation.password_form_invalid.text
+            == "Faltan datos en el formulario. Volvé a intentar."
+        )
+        assert (
+            templates.validation.password_failed.text
+            == "No pudimos validar tus datos. Verificá e intentá de nuevo."
+        )
+        assert (
+            templates.validation.password_already_registered.text
+            == "Esta cuenta ya está registrada. Iniciá sesión."
+        )
+        assert templates.validation.password_ok_register.text == "✅ ¡Cuenta creada!"
+        assert templates.validation.password_ok_login.text == "✅ ¡Sesión iniciada!"
+
+    def test_password_templates_override_via_constructor(self):
+        validation = ValidationMessages(
+            password_required=MessageItem(text="Custom required"),
+            password_form_invalid=MessageItem(text="Custom invalid"),
+            password_failed=MessageItem(text="Custom failed"),
+            password_already_registered=MessageItem(text="Custom already"),
+            password_ok_register=MessageItem(text="Custom ok register"),
+            password_ok_login=MessageItem(text="Custom ok login"),
+        )
+        assert validation.password_required.text == "Custom required"
+        assert validation.password_form_invalid.text == "Custom invalid"
+        assert validation.password_failed.text == "Custom failed"
+        assert validation.password_already_registered.text == "Custom already"
+        assert validation.password_ok_register.text == "Custom ok register"
+        assert validation.password_ok_login.text == "Custom ok login"
+
+    def test_password_templates_override_via_model_validate_string_coercion(self):
+        """Plain strings must coerce to MessageItem({"text": ...}) for the new keys
+        (matches the existing convention used by every sibling field)."""
+        data = {
+            "password_required": "Form please",
+            "password_form_invalid": "Bad form",
+            "password_failed": "Auth failed",
+            "password_already_registered": "Already registered",
+            "password_ok_register": "Register OK",
+            "password_ok_login": "Login OK",
+        }
+        validation = ValidationMessages.model_validate(data)
+        assert validation.password_required.text == "Form please"
+        assert validation.password_form_invalid.text == "Bad form"
+        assert validation.password_failed.text == "Auth failed"
+        assert validation.password_already_registered.text == "Already registered"
+        assert validation.password_ok_register.text == "Register OK"
+        assert validation.password_ok_login.text == "Login OK"
+
+    def test_password_templates_unknown_key_rejected(self):
+        """`extra=forbid` must keep working — typos must be caught at parse time."""
+        with pytest.raises(ValidationError):
+            ValidationMessages.model_validate(
+                {"password_unknown_key": "should not be accepted"}
+            )
+
+    def test_password_templates_serialize_in_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "validation" in item
+        for key in PASSWORD_TEMPLATE_KEYS:
+            assert key in item["validation"], (
+                f"{key} must be present in DynamoDB serialization"
+            )
+            assert item["validation"][key]["text"], (
+                f"{key} must have non-empty text in DynamoDB serialization"
+            )
+
+
 class TestMenuMessages:
     def test_create_menu_messages(self):
         menu = MenuMessages(

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -459,6 +459,44 @@ class TestFeaturesConfig:
         )
         assert features_momio.alias_probabilities == AliasProbabilities.MOMIO
 
+    def test_features_config_default_fixture_range_days(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+        )
+        assert features.fixture_range_days == 7
+
+    def test_features_config_custom_fixture_range_days(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+            fixture_range_days=30,
+        )
+        assert features.fixture_range_days == 30
+
+    def test_features_config_invalid_fixture_range_days(self):
+        from pydantic import ValidationError
+
+        for invalid in (0, -1, 366, 1000):
+            with pytest.raises(ValidationError):
+                FeaturesConfig(
+                    odd_type=OddType.DECIMAL,
+                    validation=ValidationMethod.EMAIL,
+                    combos=True,
+                    chatbet_version=ChatbetVersion.V2,
+                    multigames_response=True,
+                    see_in_combo=True,
+                    fixture_range_days=invalid,
+                )
+
 
 class TestMeta:
     def test_create_meta_with_defaults(self):

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -2,6 +2,8 @@ import pytest
 from datetime import datetime
 from decimal import Decimal
 
+from pydantic import ValidationError
+
 from chatbet_base_models.site_config_model import (
     OddType,
     ValidationMethod,
@@ -24,6 +26,7 @@ from chatbet_base_models.site_config_model import (
     LocaleConfig,
     FeaturesConfig,
     Meta,
+    AuthConfig,
     SiteConfig,
     SiteConfigDB,
 )
@@ -567,3 +570,168 @@ class TestSiteConfigDB:
         item = config_db.to_dynamodb_item()
 
         assert item["integrations"]["twilio"]["authentication_type"] is None
+
+
+# ==========================="
+# AuthConfig + SiteConfig auth validators
+# ==========================="
+
+
+def _identity_factory():
+    return Identity(
+        site_name="Test Site",
+        company_id="test123",
+        site_url="https://test.example.com",
+    )
+
+
+def _meta_whatsapp_integration():
+    """WhatsApp integration with Meta Cloud API provider (compatible with password)."""
+    return WhatsAppIntegration(
+        enabled=True,
+        config=WhatsAppConfig(
+            provider="meta",
+            phone_id="phone-123",
+            auth_token="token-abc",
+        ),
+    )
+
+
+def _whapi_whatsapp_integration():
+    """WhatsApp integration with WHAPI provider (incompatible with password)."""
+    return WhatsAppIntegration(
+        enabled=True,
+        config=WhapiConfig(
+            provider="whapi",
+            api_url="https://placeholder.com",
+            token="",
+        ),
+    )
+
+
+def _site_config_with_integrations(*, whatsapp=None, **overrides) -> SiteConfig:
+    """Build a SiteConfig with explicit Integrations (whatsapp can be None or absent)."""
+    integrations_kwargs = {}
+    if whatsapp is not None:
+        integrations_kwargs["whatsapp"] = whatsapp
+    integrations = Integrations(**integrations_kwargs)
+    return SiteConfig(
+        identity=_identity_factory(),
+        integrations=integrations,
+        **overrides,
+    )
+
+
+class TestAuthConfig:
+    """Unit tests for the AuthConfig model itself (no SiteConfig context)."""
+
+    def test_auth_config_defaults_otp_for_backward_compat(self):
+        """1) Default AuthConfig() ⇒ method='otp', flow_id=None, forgot_password_url=None."""
+        cfg = AuthConfig()
+        assert cfg.method == "otp"
+        assert cfg.flow_id is None
+        assert cfg.forgot_password_url is None
+
+    def test_auth_config_explicit_otp(self):
+        cfg = AuthConfig(method="otp")
+        assert cfg.method == "otp"
+        assert cfg.flow_id is None
+
+    def test_auth_config_password_with_flow_id_parses(self):
+        """2) AuthConfig(method='password', flow_id='123456') parses fine."""
+        cfg = AuthConfig(method="password", flow_id="123456")
+        assert cfg.method == "password"
+        assert cfg.flow_id == "123456"
+        assert cfg.forgot_password_url is None
+
+    def test_auth_config_invalid_method_rejected(self):
+        """3) AuthConfig(method='magic_link') raises ValidationError (Literal violation)."""
+        with pytest.raises(ValidationError):
+            AuthConfig(method="magic_link")
+
+    def test_auth_config_forgot_password_url_accepts_https(self):
+        cfg = AuthConfig(forgot_password_url="https://example.com/forgot")
+        assert str(cfg.forgot_password_url) == "https://example.com/forgot"
+
+    def test_auth_config_extra_field_forbidden(self):
+        with pytest.raises(ValidationError):
+            AuthConfig(method="otp", unexpected="x")
+
+
+class TestSiteConfigAuthBackwardCompat:
+    """SiteConfig must default to OTP when no auth block is supplied."""
+
+    def test_site_config_without_auth_defaults_to_otp(self):
+        """4) SiteConfig(...without auth...) ⇒ site.auth.method == 'otp'."""
+        config = SiteConfig(identity=_identity_factory())
+        assert config.auth is not None
+        assert config.auth.method == "otp"
+        assert config.auth.flow_id is None
+
+    def test_site_config_default_factory_keeps_otp_default(self):
+        config = SiteConfig.default_factory("Test Site", "test123")
+        assert config.auth.method == "otp"
+
+
+class TestSiteConfigAuthValidators:
+    """SiteConfig.model_validator(after) covering password/whapi/flow_id rules."""
+
+    def test_password_with_meta_provider_parses(self):
+        """5) auth.method='password' + flow_id + provider='meta' → parses fine."""
+        config = _site_config_with_integrations(
+            whatsapp=_meta_whatsapp_integration(),
+            auth=AuthConfig(method="password", flow_id="flow-123"),
+        )
+        assert config.auth.method == "password"
+        assert config.auth.flow_id == "flow-123"
+        # Confirm sibling integrations is intact (provider visible)
+        assert config.integrations.whatsapp.config.provider == "meta"
+
+    def test_password_with_whapi_provider_rejected(self):
+        """6) auth.method='password' + provider='whapi' → ValidationError mentioning 'whapi' and 'Cloud API'."""
+        with pytest.raises(ValidationError) as exc_info:
+            _site_config_with_integrations(
+                whatsapp=_whapi_whatsapp_integration(),
+                auth=AuthConfig(method="password", flow_id="flow-123"),
+            )
+
+        msg = str(exc_info.value)
+        assert "whapi" in msg
+        assert "Cloud API" in msg
+
+    def test_password_without_flow_id_rejected(self):
+        """7) auth.method='password' + no flow_id → ValidationError mentioning 'flow_id'."""
+        with pytest.raises(ValidationError) as exc_info:
+            _site_config_with_integrations(
+                whatsapp=_meta_whatsapp_integration(),
+                auth=AuthConfig(method="password"),
+            )
+
+        msg = str(exc_info.value)
+        assert "flow_id" in msg
+
+    def test_password_without_whatsapp_integration_passes(self):
+        """8) No `integrations.whatsapp` block + auth.method='password' + flow_id set → parses (whapi check skipped)."""
+        config = _site_config_with_integrations(
+            whatsapp=None,
+            auth=AuthConfig(method="password", flow_id="flow-123"),
+        )
+        assert config.auth.method == "password"
+        assert config.integrations.whatsapp is None
+
+    def test_otp_method_with_whapi_is_unaffected(self):
+        """OTP operators with whapi must remain valid (regression guard)."""
+        config = _site_config_with_integrations(
+            whatsapp=_whapi_whatsapp_integration(),
+            auth=AuthConfig(method="otp"),
+        )
+        assert config.auth.method == "otp"
+        assert config.integrations.whatsapp.config.provider == "whapi"
+
+    def test_legacy_config_without_auth_block_with_whapi_passes(self):
+        """Pre-existing operators (no auth block, whapi provider) must keep working."""
+        config = _site_config_with_integrations(
+            whatsapp=_whapi_whatsapp_integration(),
+        )
+        assert config.auth.method == "otp"
+        assert config.integrations.whatsapp.config.provider == "whapi"


### PR DESCRIPTION
## Release 2026-05-27 (staging → main)

Promoción de cambios de sprint a producción.

### Commits
- feat(combos): add min_legs_warning message template (CU-86ahjuant)
- feat(site_config): add optional fixture_range_days to FeaturesConfig
- feat(registration): add account_not_found template for platform-unknown UX
- feat: add markets_back_options and markets_more_options to LabelMessages
- feat: add AuthConfig and password validation message templates

_Rama release cortada desde `staging`. Sin conflictos con `main`._