### PR TITLE
feat(message-template): add terms_not_accepted to ValidationMessages

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -188,6 +188,9 @@ class ValidationMessages(BaseModel):
     error_otp: Optional[MessageItem] = None
     blocked_otp: Optional[MessageItem] = None
     blocked_user: Optional[MessageItem] = None
+    # Plannatech `terms_not_accepted` (Result=-1219) signaling.
+    # See SDD change `terms-not-accepted`.
+    terms_not_accepted: Optional[MessageItem] = None
     # Password-auth POC templates (sibling to OTP templates).
     # See SDD change `password-auth-poc`.
     password_required: Optional[MessageItem] = None

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -260,6 +260,68 @@ class TestValidationMessagesPasswordTemplates:
             )
 
 
+class TestValidationMessagesTermsNotAccepted:
+    """Validate the `terms_not_accepted` template added under ValidationMessages.
+
+    See SDD change `terms-not-accepted`. Plannatech surfaces error code -1219
+    when a Betcris account has not approved the platform's Terms & Conditions;
+    operators may configure a per-company message via the backoffice. The field
+    is `Optional[MessageItem] = None` so existing DynamoDB items without the key
+    must deserialize unchanged (no migration)."""
+
+    def test_terms_not_accepted_defaults_to_none(self):
+        validation = ValidationMessages()
+        assert validation.terms_not_accepted is None
+
+    def test_legacy_validation_dict_without_terms_not_accepted_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must
+        load and leave `terms_not_accepted` as `None` (no migration required).
+
+        Only fields without `send_otp`-callback validators are included here
+        because those are independently required when present; this matches a
+        legacy DDB item where only the simple validation fields were persisted."""
+        legacy = {
+            "member_validation": {"text": "Please validate"},
+            "blocked_otp": {"text": "Too many attempts"},
+            "blocked_user": {"text": "You are blocked"},
+        }
+        validation = ValidationMessages.model_validate(legacy)
+        assert validation.terms_not_accepted is None
+        assert validation.member_validation.text == "Please validate"
+        assert validation.blocked_user.text == "You are blocked"
+
+    def test_terms_not_accepted_round_trip_via_model_validate_and_dump(self):
+        """New dict with the field round-trips through model_validate → model_dump."""
+        configured_text = (
+            "Your account has not approved the Terms and Conditions on the "
+            "platform. Please complete that step and try again."
+        )
+        data = {"terms_not_accepted": {"text": configured_text}}
+        validation = ValidationMessages.model_validate(data)
+        assert validation.terms_not_accepted is not None
+        assert validation.terms_not_accepted.text == configured_text
+
+        dumped = validation.model_dump(exclude_none=True)
+        assert "terms_not_accepted" in dumped
+        assert dumped["terms_not_accepted"]["text"] == configured_text
+
+        reloaded = ValidationMessages.model_validate(dumped)
+        assert reloaded.terms_not_accepted.text == configured_text
+
+    def test_terms_not_accepted_string_coercion(self):
+        """Plain strings must coerce to MessageItem({"text": ...}) for the new key
+        (matches the existing convention used by every sibling field)."""
+        data = {"terms_not_accepted": "Terms not accepted"}
+        validation = ValidationMessages.model_validate(data)
+        assert validation.terms_not_accepted.text == "Terms not accepted"
+
+    def test_terms_not_accepted_override_via_constructor(self):
+        validation = ValidationMessages(
+            terms_not_accepted=MessageItem(text="Please accept the T&C"),
+        )
+        assert validation.terms_not_accepted.text == "Please accept the T&C"
+
+
 class TestRegistrationMessages:
     def test_create_registration_messages_with_all_fields(self):
         registration = RegistrationMessages(


### PR DESCRIPTION
## Summary

Adds `terms_not_accepted: Optional[MessageItem] = None` to `ValidationMessages` to support a configurable message when a user's account has not approved the platform's Terms & Conditions during login.

This is **Phase 1 of 6** in the SDD change [`terms-not-accepted`](https://app.clickup.com/t/86ahdd7et). It establishes the model contract that downstream services (`sportbook_services`, `bet-bot`, `chatbet-backoffice`) will consume after their submodule bumps.

ClickUp task: [86ahrxchb](https://app.clickup.com/t/86ahrxchb)

## Changes

- `chatbet_base_models/message_template.py`: new optional field on `ValidationMessages` (after `blocked_user`)
- `tests/test_message_template.py`: 5 new tests in `TestValidationMessagesTermsNotAccepted` covering default-None, legacy-dict deserialization, model_validate ↔ model_dump round-trip, string coercion, and constructor override

## Backwards compatibility

Field is `Optional[MessageItem] = None` — existing DynamoDB items without the field deserialize fine; no migration required.

## Tests

- 355 passed (full suite)
- Coverage: 92% (threshold 80%)

## Merge order (cross-repo coordination)

This PR must merge **first**. After merge:
1. Submodule bumps in `bet-bot/libs/chatbet-base-models/` and `chatbet-backoffice/chatbet-base-models/` (Phase 2)
2. Then `sportbook_services`, `bet-bot`, `chatbet-backoffice/frontend` can land in parallel (Phases 3-5)
3. Otherwise CI fails in downstream repos due to pinned base-models version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable messaging support for terms not accepted in validation responses.

* **Tests**
  * Added comprehensive test coverage for the new terms acceptance messaging functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIChatBet/chatbet-base-models/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->