### PR TITLE
feat(message-template): add live_disclaimer to BetsMessages

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -289,6 +289,7 @@ class BetsMessages(BaseModel):
     invalid_bet_amount: Optional[MessageItem] = None
     fixture_odds: Optional[MessageItem] = None
     special_bets_odds: Optional[MessageItem] = None
+    live_disclaimer: Optional[MessageItem] = None
     unavailable_odds: Optional[MessageItem] = None
     placed_bet: Optional[MessageItem] = None
     placed_bet_menu: Optional[MessageItem] = None

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -399,6 +399,65 @@ class TestBetsMessages:
         assert bets.bet_amount.text == "Enter amount"
 
 
+class TestBetsMessagesLiveDisclaimer:
+    """Validate the `live_disclaimer` template added under BetsMessages.
+
+    Operators can configure a per-company disclaimer shown to users when they
+    open the markets of a live (in-play) fixture. The field is
+    `Optional[MessageItem] = None` so existing DynamoDB items without the key
+    must deserialize unchanged (no migration)."""
+
+    def test_live_disclaimer_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.live_disclaimer is None
+
+    def test_legacy_bets_dict_without_live_disclaimer_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must
+        load and leave `live_disclaimer` as `None` (no migration required)."""
+        legacy = {
+            "select_sport": {"text": "Select sport"},
+            "bet_amount": {"text": "Enter amount"},
+            "fixture_odds": {"text": "Here are the odds"},
+            "placed_bet": {"text": "Bet placed"},
+        }
+        bets = BetsMessages.model_validate(legacy)
+        assert bets.live_disclaimer is None
+        assert bets.select_sport.text == "Select sport"
+        assert bets.fixture_odds.text == "Here are the odds"
+        assert bets.placed_bet.text == "Bet placed"
+
+    def test_live_disclaimer_round_trip_via_model_validate_and_dump(self):
+        """New dict with the field round-trips through model_validate → model_dump."""
+        configured_text = (
+            "This fixture is live. Odds may change quickly while the event "
+            "is in progress."
+        )
+        data = {"live_disclaimer": {"text": configured_text}}
+        bets = BetsMessages.model_validate(data)
+        assert bets.live_disclaimer is not None
+        assert bets.live_disclaimer.text == configured_text
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert "live_disclaimer" in dumped
+        assert dumped["live_disclaimer"]["text"] == configured_text
+
+        reloaded = BetsMessages.model_validate(dumped)
+        assert reloaded.live_disclaimer.text == configured_text
+
+    def test_live_disclaimer_string_coercion(self):
+        """Plain strings must coerce to MessageItem({"text": ...}) for the new key
+        (matches the existing convention used by every sibling field)."""
+        data = {"live_disclaimer": "Live fixture — odds may change"}
+        bets = BetsMessages.model_validate(data)
+        assert bets.live_disclaimer.text == "Live fixture — odds may change"
+
+    def test_live_disclaimer_override_via_constructor(self):
+        bets = BetsMessages(
+            live_disclaimer=MessageItem(text="Heads up: this is a live match"),
+        )
+        assert bets.live_disclaimer.text == "Heads up: this is a live match"
+
+
 class TestCombosMessages:
     def test_create_combos_messages(self):
         combos = CombosMessages(


### PR DESCRIPTION
## Summary

Adds `live_disclaimer: Optional[MessageItem] = None` to `BetsMessages` so each company can configure a disclaimer shown to the user when they open the markets of a live (in-play) fixture.

This is **Phase 1 of 3** in the cross-repo change for the live-disclaimer feature.

ClickUp task: [86ahpy620](https://app.clickup.com/t/86ahpy620)

## Changes

- `chatbet_base_models/message_template.py`: new optional field on `BetsMessages`
- `tests/test_message_template.py`: new test class covering default-None, legacy-dict, round-trip, constructor override

## Backwards compatibility

Field is `Optional[MessageItem] = None`. Existing DynamoDB items deserialize fine. No migration required.

## Merge order

This PR merges first. Downstream consumers (`chatbet-backoffice` PR #612, bet-bot PR forthcoming) wait on `develop`.

## Tests

- Full suite passing: 360 tests passed
- Coverage: 92% overall (`message_template.py` at 91%), well above the 80% threshold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional live disclaimer messaging capability for betting communications.

* **Tests**
  * Added test coverage validating live disclaimer message behavior, including default values, data parsing, and message transformation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->