### PR TITLE
feat(staging): add terms_not_accepted to ValidationMessages (cherry-pick)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -188,6 +188,9 @@ class ValidationMessages(BaseModel):
     error_otp: Optional[MessageItem] = None
     blocked_otp: Optional[MessageItem] = None
     blocked_user: Optional[MessageItem] = None
+    # Plannatech `terms_not_accepted` (Result=-1219) signaling.
+    # See SDD change `terms-not-accepted`.
+    terms_not_accepted: Optional[MessageItem] = None
     # Password-auth POC templates (sibling to OTP templates).
     # See SDD change `password-auth-poc`.
     password_required: Optional[MessageItem] = None

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -260,6 +260,68 @@ class TestValidationMessagesPasswordTemplates:
             )
 
 
+class TestValidationMessagesTermsNotAccepted:
+    """Validate the `terms_not_accepted` template added under ValidationMessages.
+
+    See SDD change `terms-not-accepted`. Plannatech surfaces error code -1219
+    when a Betcris account has not approved the platform's Terms & Conditions;
+    operators may configure a per-company message via the backoffice. The field
+    is `Optional[MessageItem] = None` so existing DynamoDB items without the key
+    must deserialize unchanged (no migration)."""
+
+    def test_terms_not_accepted_defaults_to_none(self):
+        validation = ValidationMessages()
+        assert validation.terms_not_accepted is None
+
+    def test_legacy_validation_dict_without_terms_not_accepted_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must
+        load and leave `terms_not_accepted` as `None` (no migration required).
+
+        Only fields without `send_otp`-callback validators are included here
+        because those are independently required when present; this matches a
+        legacy DDB item where only the simple validation fields were persisted."""
+        legacy = {
+            "member_validation": {"text": "Please validate"},
+            "blocked_otp": {"text": "Too many attempts"},
+            "blocked_user": {"text": "You are blocked"},
+        }
+        validation = ValidationMessages.model_validate(legacy)
+        assert validation.terms_not_accepted is None
+        assert validation.member_validation.text == "Please validate"
+        assert validation.blocked_user.text == "You are blocked"
+
+    def test_terms_not_accepted_round_trip_via_model_validate_and_dump(self):
+        """New dict with the field round-trips through model_validate → model_dump."""
+        configured_text = (
+            "Your account has not approved the Terms and Conditions on the "
+            "platform. Please complete that step and try again."
+        )
+        data = {"terms_not_accepted": {"text": configured_text}}
+        validation = ValidationMessages.model_validate(data)
+        assert validation.terms_not_accepted is not None
+        assert validation.terms_not_accepted.text == configured_text
+
+        dumped = validation.model_dump(exclude_none=True)
+        assert "terms_not_accepted" in dumped
+        assert dumped["terms_not_accepted"]["text"] == configured_text
+
+        reloaded = ValidationMessages.model_validate(dumped)
+        assert reloaded.terms_not_accepted.text == configured_text
+
+    def test_terms_not_accepted_string_coercion(self):
+        """Plain strings must coerce to MessageItem({"text": ...}) for the new key
+        (matches the existing convention used by every sibling field)."""
+        data = {"terms_not_accepted": "Terms not accepted"}
+        validation = ValidationMessages.model_validate(data)
+        assert validation.terms_not_accepted.text == "Terms not accepted"
+
+    def test_terms_not_accepted_override_via_constructor(self):
+        validation = ValidationMessages(
+            terms_not_accepted=MessageItem(text="Please accept the T&C"),
+        )
+        assert validation.terms_not_accepted.text == "Please accept the T&C"
+
+
 class TestRegistrationMessages:
     def test_create_registration_messages_with_all_fields(self):
         registration = RegistrationMessages(


### PR DESCRIPTION
Cherry-pick aislado del feature **terms_not_accepted** (rechazo de T&C de Plannatech, `errorCode -1219`, company Betcris) desde `develop` hacia `staging`. NO arrastra el resto de develop (migración a ECS, combos, etc.).

ClickUp: 86ahrxchb

### Orden de merge (CRÍTICO)
1. `chatbet-base-models` ← este PR primero
2. `chatbet-backoffice`
3. `chatbet-channel-services` (bet-bot) ← último (su build de staging instala `chatbet-base-models@staging`)

### Nota de verificación funcional
El mapeo `-1219 → HTTP 401` en sportbook lo tiene otro dev (PR #545 cerrado). Hasta que eso esté en staging, la rama de detección en bet-bot es código muerto: el feature se sube pero no se puede verificar end-to-end todavía.

### Este PR (merge #1)
Agrega el campo `terms_not_accepted: Optional[MessageItem]` a `ValidationMessages`. +65 líneas (modelo + tests).