### PR TITLE
feat(staging): cherry-pick live_disclaimer

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -289,6 +289,7 @@ class BetsMessages(BaseModel):
     invalid_bet_amount: Optional[MessageItem] = None
     fixture_odds: Optional[MessageItem] = None
     special_bets_odds: Optional[MessageItem] = None
+    live_disclaimer: Optional[MessageItem] = None
     unavailable_odds: Optional[MessageItem] = None
     placed_bet: Optional[MessageItem] = None
     placed_bet_menu: Optional[MessageItem] = None

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -399,6 +399,65 @@ class TestBetsMessages:
         assert bets.bet_amount.text == "Enter amount"
 
 
+class TestBetsMessagesLiveDisclaimer:
+    """Validate the `live_disclaimer` template added under BetsMessages.
+
+    Operators can configure a per-company disclaimer shown to users when they
+    open the markets of a live (in-play) fixture. The field is
+    `Optional[MessageItem] = None` so existing DynamoDB items without the key
+    must deserialize unchanged (no migration)."""
+
+    def test_live_disclaimer_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.live_disclaimer is None
+
+    def test_legacy_bets_dict_without_live_disclaimer_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must
+        load and leave `live_disclaimer` as `None` (no migration required)."""
+        legacy = {
+            "select_sport": {"text": "Select sport"},
+            "bet_amount": {"text": "Enter amount"},
+            "fixture_odds": {"text": "Here are the odds"},
+            "placed_bet": {"text": "Bet placed"},
+        }
+        bets = BetsMessages.model_validate(legacy)
+        assert bets.live_disclaimer is None
+        assert bets.select_sport.text == "Select sport"
+        assert bets.fixture_odds.text == "Here are the odds"
+        assert bets.placed_bet.text == "Bet placed"
+
+    def test_live_disclaimer_round_trip_via_model_validate_and_dump(self):
+        """New dict with the field round-trips through model_validate → model_dump."""
+        configured_text = (
+            "This fixture is live. Odds may change quickly while the event "
+            "is in progress."
+        )
+        data = {"live_disclaimer": {"text": configured_text}}
+        bets = BetsMessages.model_validate(data)
+        assert bets.live_disclaimer is not None
+        assert bets.live_disclaimer.text == configured_text
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert "live_disclaimer" in dumped
+        assert dumped["live_disclaimer"]["text"] == configured_text
+
+        reloaded = BetsMessages.model_validate(dumped)
+        assert reloaded.live_disclaimer.text == configured_text
+
+    def test_live_disclaimer_string_coercion(self):
+        """Plain strings must coerce to MessageItem({"text": ...}) for the new key
+        (matches the existing convention used by every sibling field)."""
+        data = {"live_disclaimer": "Live fixture — odds may change"}
+        bets = BetsMessages.model_validate(data)
+        assert bets.live_disclaimer.text == "Live fixture — odds may change"
+
+    def test_live_disclaimer_override_via_constructor(self):
+        bets = BetsMessages(
+            live_disclaimer=MessageItem(text="Heads up: this is a live match"),
+        )
+        assert bets.live_disclaimer.text == "Heads up: this is a live match"
+
+
 class TestCombosMessages:
     def test_create_combos_messages(self):
         combos = CombosMessages(


### PR DESCRIPTION
## Summary

Promotes the `live_disclaimer` feature from `develop` to `staging` for deployment validation.

This is a clean cherry-pick of the original feat commit from PR #150 (merged to `develop` on 2026-06-01). No additional changes — same code that passed CI and tests on develop.

ClickUp task: [86ahpy620](https://app.clickup.com/t/86ahpy620)

## What changes

Adds `live_disclaimer: Optional[MessageItem]` to `BetsMessages`

## Original PR (develop)

#150 — see for full discussion, test results, and review history.

## Related PRs (cross-repo)

- chatbet-base-models: `release/live-disclaimer-staging` → staging
- chatbet-backoffice: `release/live-disclaimer-staging` → staging
- chatbet-channel-services: `release/live-disclaimer-staging` → staging

All three must land on staging together for the feature to work end-to-end.

## Verify in staging

1. Open the markets of a live (in-play) fixture from any sportsbook (Plannatech/Phoenix/Digitain/BetBy/iSolutions)
2. Confirm the disclaimer appears as a separate message BEFORE the markets buttons
3. Test the EN fallback (no company template configured)
4. Optional: operator configures custom text from BO → re-test