### PR TITLE
feat: add bet_rejected_duplicate message template field

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -296,6 +296,7 @@ class BetsMessages(BaseModel):
     without_funds: Optional[MessageItem] = None
     deposit: Optional[MessageItem] = None
     bet_rejected: Optional[MessageItem] = None
+    bet_rejected_duplicate: Optional[MessageItem] = None
     select_type_of_bet: Optional[MessageItem] = None
     closed_fixture: Optional[MessageItem] = None
 
@@ -1061,6 +1062,12 @@ class MessageTemplates(BaseModel):
                 ),
                 bet_rejected=MessageItem(
                     text="Your bet was rejected. Please try again."
+                ),
+                bet_rejected_duplicate=MessageItem(
+                    text=(
+                        "You already have the maximum identical bets for this event. "
+                        "Try a different amount or selection."
+                    )
                 ),
                 closed_fixture=MessageItem(
                     text="Fixture is closed. You cannot place bets on this fixture."

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -458,6 +458,64 @@ class TestBetsMessagesLiveDisclaimer:
         assert bets.live_disclaimer.text == "Heads up: this is a live match"
 
 
+class TestBetsMessagesBetRejectedDuplicate:
+    """Validate the `bet_rejected_duplicate` template added under BetsMessages.
+
+    Operators can configure a per-company message shown when a bet is rejected
+    because the user already has the maximum number of identical bets for an
+    event. The field is `Optional[MessageItem] = None` so existing DynamoDB
+    items without the key must deserialize unchanged (no migration)."""
+
+    def test_from_minimal_seeds_bet_rejected_duplicate(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.bets.bet_rejected_duplicate is not None
+        assert "maximum identical bets" in templates.bets.bet_rejected_duplicate.text
+
+    def test_bet_rejected_duplicate_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.bet_rejected_duplicate is None
+
+    def test_legacy_bets_dict_without_bet_rejected_duplicate_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must
+        load and leave `bet_rejected_duplicate` as `None` (no migration required).
+
+        Critical because BetsMessages uses ConfigDict(extra="forbid")."""
+        legacy = {
+            "select_sport": {"text": "Select sport"},
+            "bet_amount": {"text": "Enter amount"},
+            "bet_rejected": {"text": "Your bet was rejected. Please try again."},
+            "placed_bet": {"text": "Bet placed"},
+        }
+        bets = BetsMessages.model_validate(legacy)
+        assert bets.bet_rejected_duplicate is None
+        assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
+        assert bets.select_sport.text == "Select sport"
+
+    def test_bet_rejected_duplicate_round_trip_via_model_validate_and_dump(self):
+        """New dict with the field round-trips through model_validate → model_dump."""
+        configured_text = (
+            "You already have the maximum identical bets for this event. "
+            "Try a different amount or selection."
+        )
+        data = {"bet_rejected_duplicate": {"text": configured_text}}
+        bets = BetsMessages.model_validate(data)
+        assert bets.bet_rejected_duplicate is not None
+        assert bets.bet_rejected_duplicate.text == configured_text
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert "bet_rejected_duplicate" in dumped
+        assert dumped["bet_rejected_duplicate"]["text"] == configured_text
+
+        reloaded = BetsMessages.model_validate(dumped)
+        assert reloaded.bet_rejected_duplicate.text == configured_text
+
+    def test_bet_rejected_duplicate_override_via_constructor(self):
+        bets = BetsMessages(
+            bet_rejected_duplicate=MessageItem(text="You hit the duplicate limit"),
+        )
+        assert bets.bet_rejected_duplicate.text == "You hit the duplicate limit"
+
+
 class TestCombosMessages:
     def test_create_combos_messages(self):
         combos = CombosMessages(


### PR DESCRIPTION
## What
Adds `BetsMessages.bet_rejected_duplicate` (Optional[MessageItem]) to the shared MessageTemplates model, plus a default in `from_minimal()`.

## Why
bet-bot currently **hardcodes** the duplicate-bet rejection copy (ISolutions ResultCode -32, "only 2 identical bets allowed"). We're moving it to company config (DynamoDB) so each operator can edit it from the backoffice, per the platform's multi-tenant template convention. This PR defines the field; bet-bot (read) and backoffice (edit) PRs depend on it.

## Backward compatibility
- Field is `Optional[MessageItem] = None`; existing DynamoDB items lacking the key still deserialize under `extra="forbid"` (covered by a new legacy-dict test).
- `model_config` unchanged.

## ⚠️ Deploy order
This must merge & be pinned by readers (bet-bot, backoffice) **before** the key is populated in DynamoDB — `extra="forbid"` means a reader on the old model would reject the new key.

## Tests
New `TestBetsMessagesBetRejectedDuplicate` (5 cases: seed, default-None, legacy-dict backward-compat, round-trip, constructor override). Full file: 131 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-facing messaging for duplicate bet rejection. Users will now receive clear feedback when they attempt to place identical bets that exceed the event limit, with guidance to try a different amount or selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->