### PR TITLE
feat: Plannatech account-state errorType template fields

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -191,6 +191,24 @@ class ValidationMessages(BaseModel):
     # Plannatech `terms_not_accepted` (Result=-1219) signaling.
     # See SDD change `terms-not-accepted`.
     terms_not_accepted: Optional[MessageItem] = None
+    # Plannatech errorType -> operator-configurable account-state UX.
+    # See SDD change `plannatech-errortype-mapping`. Each mirrors the stable
+    # errorType string (snake_case) under `validation.*`. Absent -> hardcoded
+    # localized fallback in bet-bot (no crash). Infra types
+    # (Timeout/UpstreamError/UnexpectedError/ServiceUnavailable) are NOT
+    # configurable (hardcoded fallbacks); SessionExpired IS configurable.
+    terms_version_outdated: Optional[MessageItem] = None
+    otp_attempts_exceeded: Optional[MessageItem] = None
+    account_blocked_by_request: Optional[MessageItem] = None
+    two_factor_inactive: Optional[MessageItem] = None
+    self_excluded: Optional[MessageItem] = None
+    betting_time_expired: Optional[MessageItem] = None
+    session_expired: Optional[MessageItem] = None
+    # Identity/auth errorTypes reused by login + balance flows (D3: balance
+    # reuses `validation.*`, no dedicated `balance_*` fields).
+    unauthorized_user: Optional[MessageItem] = None
+    user_not_found: Optional[MessageItem] = None
+    account_blocked: Optional[MessageItem] = None
     # Password-auth POC templates (sibling to OTP templates).
     # See SDD change `password-auth-poc`.
     password_required: Optional[MessageItem] = None
@@ -299,6 +317,13 @@ class BetsMessages(BaseModel):
     bet_rejected_duplicate: Optional[MessageItem] = None
     select_type_of_bet: Optional[MessageItem] = None
     closed_fixture: Optional[MessageItem] = None
+    # Plannatech errorType -> operator-configurable business-facing bet UX.
+    # See SDD change `plannatech-errortype-mapping`. InsufficientBalance reuses
+    # the existing `without_funds` field; these cover the remaining business
+    # types not already represented.
+    market_unavailable: Optional[MessageItem] = None
+    bet_limit_exceeded: Optional[MessageItem] = None
+    bet_amount_too_low: Optional[MessageItem] = None
 
     @field_validator("select_type_of_bet")
     @classmethod

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -322,6 +322,89 @@ class TestValidationMessagesTermsNotAccepted:
         assert validation.terms_not_accepted.text == "Please accept the T&C"
 
 
+class TestValidationMessagesPlannatechErrorTypes:
+    """Validate the operator-configurable account-state templates added under
+    ValidationMessages for SDD change `plannatech-errortype-mapping`.
+
+    sportbook PR #588 normalized Plannatech `errorType` into a stable enum;
+    these fields mirror that string in snake_case under `validation.*`. Each is
+    `Optional[MessageItem] = None` so legacy DDB items without the keys must
+    deserialize unchanged (no migration). `session_expired` is configurable;
+    infra types (Timeout/UpstreamError/UnexpectedError/ServiceUnavailable) are
+    intentionally NOT modeled here (hardcoded fallbacks in bet-bot)."""
+
+    NEW_FIELDS = [
+        "terms_version_outdated",
+        "otp_attempts_exceeded",
+        "account_blocked_by_request",
+        "two_factor_inactive",
+        "self_excluded",
+        "betting_time_expired",
+        "session_expired",
+        "unauthorized_user",
+        "user_not_found",
+        "account_blocked",
+    ]
+
+    @pytest.mark.parametrize("field", NEW_FIELDS)
+    def test_field_defaults_to_none(self, field):
+        validation = ValidationMessages()
+        assert getattr(validation, field) is None
+
+    def test_infra_types_are_not_configurable_fields(self):
+        """Infra types are hardcoded fallbacks, NOT operator-configurable; with
+        `extra="forbid"` they must raise rather than silently load."""
+        for infra in ("timeout", "upstream_error", "unexpected_error", "service_unavailable"):
+            with pytest.raises(ValidationError):
+                ValidationMessages.model_validate({infra: {"text": "x"}})
+
+    @pytest.mark.parametrize("field", NEW_FIELDS)
+    def test_field_round_trip_via_model_validate_and_dump(self, field):
+        configured_text = f"Configured {field}"
+        validation = ValidationMessages.model_validate({field: {"text": configured_text}})
+        assert getattr(validation, field).text == configured_text
+
+        dumped = validation.model_dump(exclude_none=True)
+        assert dumped[field]["text"] == configured_text
+
+        reloaded = ValidationMessages.model_validate(dumped)
+        assert getattr(reloaded, field).text == configured_text
+
+    @pytest.mark.parametrize("field", NEW_FIELDS)
+    def test_field_string_coercion(self, field):
+        validation = ValidationMessages.model_validate({field: "plain string"})
+        assert getattr(validation, field).text == "plain string"
+
+    def test_session_expired_is_configurable(self):
+        """Spec decision D2: SessionExpired IS configurable (actionable auth
+        state), unlike the other infra types."""
+        validation = ValidationMessages(session_expired=MessageItem(text="Sign in again"))
+        assert validation.session_expired.text == "Sign in again"
+
+
+class TestBetsMessagesPlannatechErrorTypes:
+    """Validate the operator-configurable business-facing bet templates added
+    under BetsMessages for SDD change `plannatech-errortype-mapping`.
+
+    InsufficientBalance reuses the existing `without_funds` field; these cover
+    the remaining business errorTypes. Each is `Optional[MessageItem] = None`."""
+
+    NEW_FIELDS = ["market_unavailable", "bet_limit_exceeded", "bet_amount_too_low"]
+
+    @pytest.mark.parametrize("field", NEW_FIELDS)
+    def test_field_defaults_to_none(self, field):
+        bets = BetsMessages()
+        assert getattr(bets, field) is None
+
+    @pytest.mark.parametrize("field", NEW_FIELDS)
+    def test_field_round_trip_and_string_coercion(self, field):
+        bets = BetsMessages.model_validate({field: "plain string"})
+        assert getattr(bets, field).text == "plain string"
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert dumped[field]["text"] == "plain string"
+
+
 class TestRegistrationMessages:
     def test_create_registration_messages_with_all_fields(self):
         registration = RegistrationMessages(


### PR DESCRIPTION
## Why
sportbook-services PR #588 normalized Plannatech errors into a stable `errorType` string across all flows. channel-services must render operator-configurable, localized UX per `errorType`. This PR adds the configurable template fields they map onto.

## What
- `ValidationMessages`: +`terms_version_outdated`, `otp_attempts_exceeded`, `account_blocked_by_request`, `two_factor_inactive`, `self_excluded`, `betting_time_expired`, `session_expired`, `unauthorized_user`, `user_not_found`, `account_blocked` (all `Optional[MessageItem] = None`, mirroring `terms_not_accepted`).
- `BetsMessages`: +`market_unavailable`, `bet_limit_exceeded`, `bet_amount_too_low`.
- Infra errorTypes (Timeout/UpstreamError/UnexpectedError/ServiceUnavailable) are intentionally NOT added — those fall back to the provider's localized `message`, not operator copy.

## Merge order (cross-repo)
**This PR merges FIRST** → chatbet-backoffice → bet-bot. The bet-bot side accesses these fields defensively, but they only round-trip once this merges to develop.

## Tests
403 passed (parametrized: defaults-to-None, round-trip, string coercion, session_expired configurable, infra-type rejection under extra=forbid).

Refs ClickUp 86aj2wm7y.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging and user feedback across authentication, account management, and betting workflows. Enhanced error coverage now includes session expiration, account restrictions, bet limits, minimum bet amounts, and market availability issues for clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->