### PR TITLE
feat: localized default messages for Plannatech account-state errors

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -178,6 +178,65 @@ class OnboardingMessages(BaseModel):
         return self
 
 
+DEFAULT_ACCOUNT_STATE: Dict[str, Dict[str, str]] = {
+    "account_blocked": {
+        "es": "Lo sentimos, tu cuenta está bloqueada. Por favor, contacta a soporte.",
+        "en": "Sorry, your account is blocked. Please contact support.",
+        "pt-br": "Desculpe, sua conta está bloqueada. Entre em contato com o suporte.",
+    },
+    "unauthorized_user": {
+        "es": "No estás autorizado para realizar esta acción.",
+        "en": "You are not authorized to perform this action.",
+        "pt-br": "Você não está autorizado a realizar esta ação.",
+    },
+    "user_not_found": {
+        "es": "No encontramos una cuenta asociada. Verifica tus datos.",
+        "en": "We could not find an account. Please check your details.",
+        "pt-br": "Não encontramos uma conta. Verifique seus dados.",
+    },
+    "self_excluded": {
+        "es": "Tu cuenta se encuentra en autoexclusión.",
+        "en": "Your account is currently self-excluded.",
+        "pt-br": "Sua conta está em autoexclusão.",
+    },
+    "terms_not_accepted": {
+        "es": "Debes aceptar los términos y condiciones para continuar.",
+        "en": "You must accept the terms and conditions to continue.",
+        "pt-br": "Você precisa aceitar os termos e condições para continuar.",
+    },
+    "terms_version_outdated": {
+        "es": "Hay una nueva versión de los términos y condiciones que debes aceptar.",
+        "en": "There is a new version of the terms and conditions you need to accept.",
+        "pt-br": "Há uma nova versão dos termos e condições que você precisa aceitar.",
+    },
+    "otp_attempts_exceeded": {
+        "es": "Superaste el número de intentos permitidos. Inténtalo más tarde.",
+        "en": "You have exceeded the allowed number of attempts. Please try again later.",
+        "pt-br": "Você excedeu o número de tentativas permitidas. Tente novamente mais tarde.",
+    },
+    "two_factor_inactive": {
+        "es": "La verificación en dos pasos no está activa en tu cuenta.",
+        "en": "Two-factor authentication is not active on your account.",
+        "pt-br": "A autenticação em duas etapas não está ativa na sua conta.",
+    },
+    "betting_time_expired": {
+        "es": "El tiempo para realizar esta apuesta ha expirado.",
+        "en": "The time to place this bet has expired.",
+        "pt-br": "O tempo para fazer esta aposta expirou.",
+    },
+    "session_expired": {
+        "es": "Tu sesión ha expirado. Por favor, inicia sesión nuevamente.",
+        "en": "Your session has expired. Please log in again.",
+        "pt-br": "Sua sessão expirou. Por favor, faça login novamente.",
+    },
+    "account_blocked_by_request": {
+        "es": "Tu cuenta fue bloqueada a petición propia.",
+        "en": "Your account was blocked at your own request.",
+        "pt-br": "Sua conta foi bloqueada a seu próprio pedido.",
+    },
+}
+
+
 class ValidationMessages(BaseModel):
     model_config = ConfigDict(extra="forbid")
     member_validation: Optional[MessageItem] = None
@@ -209,6 +268,15 @@ class ValidationMessages(BaseModel):
     unauthorized_user: Optional[MessageItem] = None
     user_not_found: Optional[MessageItem] = None
     account_blocked: Optional[MessageItem] = None
+    # Localized defaults for the account-state errorTypes above, mirroring the
+    # `ErrorMessages.general_errors` rationale: auto-fills on load (model_validate /
+    # constructor) even when the Dynamo item omits it, so consumers always have a
+    # multi-language fallback. Shape: action_name -> {lang -> text}. The consumer
+    # (bet-bot) resolves [action][lang] at runtime. Operators override the per-action
+    # copy via the per-field MessageItem templates above (e.g. validation.account_blocked).
+    account_state_defaults: Dict[str, Dict[str, str]] = Field(
+        default_factory=lambda: DEFAULT_ACCOUNT_STATE
+    )
     # Password-auth POC templates (sibling to OTP templates).
     # See SDD change `password-auth-poc`.
     password_required: Optional[MessageItem] = None

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -20,6 +20,7 @@ from chatbet_base_models.message_template import (
     LinkItem,
     LinksMessages,
     DEFAULT_LINKS,
+    DEFAULT_ACCOUNT_STATE,
 )
 
 
@@ -380,6 +381,82 @@ class TestValidationMessagesPlannatechErrorTypes:
         state), unlike the other infra types."""
         validation = ValidationMessages(session_expired=MessageItem(text="Sign in again"))
         assert validation.session_expired.text == "Sign in again"
+
+
+class TestValidationMessagesAccountStateDefaults:
+    """Validate the localized `account_state_defaults` fallback added under
+    ValidationMessages for SDD change `plannatech-errortype-mapping`.
+
+    Mirrors the `ErrorMessages.general_errors` strategy: a module-level constant
+    (`DEFAULT_ACCOUNT_STATE`) auto-fills via `default_factory` on the constructor
+    and on `model_validate`, even when the Dynamo item omits the key, so the
+    consumer always has a multi-language fallback. Shape: action -> {lang -> text}.
+    Operators override the per-action copy via the per-field MessageItem templates."""
+
+    ACTIONS = [
+        "account_blocked",
+        "unauthorized_user",
+        "user_not_found",
+        "self_excluded",
+        "terms_not_accepted",
+        "terms_version_outdated",
+        "otp_attempts_exceeded",
+        "two_factor_inactive",
+        "betting_time_expired",
+        "session_expired",
+        "account_blocked_by_request",
+    ]
+    LANGS = {"es", "en", "pt-br"}
+
+    def test_defaults_with_direct_constructor(self):
+        validation = ValidationMessages()
+        assert validation.account_state_defaults is not None
+        assert set(validation.account_state_defaults.keys()) == set(self.ACTIONS)
+
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_each_action_has_all_three_languages(self, action):
+        validation = ValidationMessages()
+        langs = validation.account_state_defaults[action]
+        assert set(langs.keys()) == self.LANGS
+        for lang in self.LANGS:
+            assert isinstance(langs[lang], str) and langs[lang].strip()
+
+    def test_defaults_when_not_provided_via_model_validate(self):
+        """A DDB item WITHOUT account_state_defaults still gets the full default."""
+        validation = ValidationMessages.model_validate({"member_validation": "hello"})
+        assert validation.member_validation.text == "hello"
+        assert set(validation.account_state_defaults.keys()) == set(self.ACTIONS)
+        for action in self.ACTIONS:
+            assert set(validation.account_state_defaults[action].keys()) == self.LANGS
+
+    def test_factory_returns_constant_content(self):
+        validation = ValidationMessages()
+        assert validation.account_state_defaults == DEFAULT_ACCOUNT_STATE
+
+    def test_from_minimal_populates_account_state_defaults(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.validation is not None
+        defaults = templates.validation.account_state_defaults
+        assert set(defaults.keys()) == set(self.ACTIONS)
+        for action in self.ACTIONS:
+            assert set(defaults[action].keys()) == self.LANGS
+
+    def test_account_state_defaults_in_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "validation" in item
+        assert "account_state_defaults" in item["validation"]
+        assert set(item["validation"]["account_state_defaults"].keys()) == set(
+            self.ACTIONS
+        )
+
+    def test_operator_can_override_via_model_validate(self):
+        """Providing account_state_defaults explicitly replaces the default."""
+        custom = {"account_blocked": {"es": "x", "en": "y", "pt-br": "z"}}
+        validation = ValidationMessages.model_validate(
+            {"account_state_defaults": custom}
+        )
+        assert validation.account_state_defaults == custom
 
 
 class TestBetsMessagesPlannatechErrorTypes:


### PR DESCRIPTION
## Why
PR #156 added the account-state `validation.*` fields (account_blocked, unauthorized_user, user_not_found, self_excluded, terms_*, etc.) but they default to `None`. When an operator has not configured a template, channel-services has no localized default to render — it would fall to the provider message or a single generic string. The team does NOT want hardcoded message copy in channel-services, so the defaults belong here.

## What
Replicates the existing `DEFAULT_GENERAL_ERRORS` strategy (multi-language constant + `default_factory` field that auto-fills on `model_validate`, even when the Dynamo item omits it):

- **`DEFAULT_ACCOUNT_STATE: Dict[str, Dict[str, str]]`** — `action -> {lang -> text}`, covering all 11 account-state actions in `es` / `en` / `pt-br`. Neutral, operator-agnostic copy (no branding/phone numbers — operators still override via their own `validation.<field>` template).
- **`ValidationMessages.account_state_defaults: Dict[str, Dict[str, str]] = Field(default_factory=lambda: DEFAULT_ACCOUNT_STATE)`** — auto-populates on load. Consumer (channel-services) resolves `[action][lang]` at runtime, mirroring how `general_errors[lang]` is consumed.

`from_minimal()` unchanged (the `default_factory` covers it). Operator override path preserved.

## Language key
Uses `"pt-br"` (hyphen) to match `DEFAULT_GENERAL_ERRORS` and existing tests — NOT `pt_br`.

## Tests
+7 tests (`TestValidationMessagesAccountStateDefaults`): auto-populate on construct, all 11 actions present, es/en/pt-br per action, `model_validate` without the key still fills it, `from_minimal` populates it, DynamoDB round-trip, operator override. Suite: **420 passed, 92.30% coverage** (CI threshold 80%).

## Consumed by
channel-services `_render_account_state` will read `validation.account_state_defaults[action][lang]` as the localized fallback tier (separate PR). Merge order: this PR first, then the channel-services PR.

Refs ClickUp 86aj2wm7y.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic localized error message defaults for account validation scenarios, supporting multiple languages (English, Spanish, Portuguese-BR).
  * Implemented multi-language fallback resolution for account-state error messages, ensuring consistent user communication across validation scenarios such as blocked accounts, unauthorized access, and session expiration.

* **Tests**
  * Added comprehensive test coverage for new account validation message defaults and language fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->