### PR TITLE
feat: localized default messages for Plannatech account-state errors (staging)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -178,6 +178,65 @@ class OnboardingMessages(BaseModel):
         return self
 
 
+DEFAULT_ACCOUNT_STATE: Dict[str, Dict[str, str]] = {
+    "account_blocked": {
+        "es": "Lo sentimos, tu cuenta está bloqueada. Por favor, contacta a soporte.",
+        "en": "Sorry, your account is blocked. Please contact support.",
+        "pt-br": "Desculpe, sua conta está bloqueada. Entre em contato com o suporte.",
+    },
+    "unauthorized_user": {
+        "es": "No estás autorizado para realizar esta acción.",
+        "en": "You are not authorized to perform this action.",
+        "pt-br": "Você não está autorizado a realizar esta ação.",
+    },
+    "user_not_found": {
+        "es": "No encontramos una cuenta asociada. Verifica tus datos.",
+        "en": "We could not find an account. Please check your details.",
+        "pt-br": "Não encontramos uma conta. Verifique seus dados.",
+    },
+    "self_excluded": {
+        "es": "Tu cuenta se encuentra en autoexclusión.",
+        "en": "Your account is currently self-excluded.",
+        "pt-br": "Sua conta está em autoexclusão.",
+    },
+    "terms_not_accepted": {
+        "es": "Debes aceptar los términos y condiciones para continuar.",
+        "en": "You must accept the terms and conditions to continue.",
+        "pt-br": "Você precisa aceitar os termos e condições para continuar.",
+    },
+    "terms_version_outdated": {
+        "es": "Hay una nueva versión de los términos y condiciones que debes aceptar.",
+        "en": "There is a new version of the terms and conditions you need to accept.",
+        "pt-br": "Há uma nova versão dos termos e condições que você precisa aceitar.",
+    },
+    "otp_attempts_exceeded": {
+        "es": "Superaste el número de intentos permitidos. Inténtalo más tarde.",
+        "en": "You have exceeded the allowed number of attempts. Please try again later.",
+        "pt-br": "Você excedeu o número de tentativas permitidas. Tente novamente mais tarde.",
+    },
+    "two_factor_inactive": {
+        "es": "La verificación en dos pasos no está activa en tu cuenta.",
+        "en": "Two-factor authentication is not active on your account.",
+        "pt-br": "A autenticação em duas etapas não está ativa na sua conta.",
+    },
+    "betting_time_expired": {
+        "es": "El tiempo para realizar esta apuesta ha expirado.",
+        "en": "The time to place this bet has expired.",
+        "pt-br": "O tempo para fazer esta aposta expirou.",
+    },
+    "session_expired": {
+        "es": "Tu sesión ha expirado. Por favor, inicia sesión nuevamente.",
+        "en": "Your session has expired. Please log in again.",
+        "pt-br": "Sua sessão expirou. Por favor, faça login novamente.",
+    },
+    "account_blocked_by_request": {
+        "es": "Tu cuenta fue bloqueada a petición propia.",
+        "en": "Your account was blocked at your own request.",
+        "pt-br": "Sua conta foi bloqueada a seu próprio pedido.",
+    },
+}
+
+
 class ValidationMessages(BaseModel):
     model_config = ConfigDict(extra="forbid")
     member_validation: Optional[MessageItem] = None
@@ -209,6 +268,15 @@ class ValidationMessages(BaseModel):
     unauthorized_user: Optional[MessageItem] = None
     user_not_found: Optional[MessageItem] = None
     account_blocked: Optional[MessageItem] = None
+    # Localized defaults for the account-state errorTypes above, mirroring the
+    # `ErrorMessages.general_errors` rationale: auto-fills on load (model_validate /
+    # constructor) even when the Dynamo item omits it, so consumers always have a
+    # multi-language fallback. Shape: action_name -> {lang -> text}. The consumer
+    # (bet-bot) resolves [action][lang] at runtime. Operators override the per-action
+    # copy via the per-field MessageItem templates above (e.g. validation.account_blocked).
+    account_state_defaults: Dict[str, Dict[str, str]] = Field(
+        default_factory=lambda: DEFAULT_ACCOUNT_STATE
+    )
     # Password-auth POC templates (sibling to OTP templates).
     # See SDD change `password-auth-poc`.
     password_required: Optional[MessageItem] = None

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -20,6 +20,7 @@ from chatbet_base_models.message_template import (
     LinkItem,
     LinksMessages,
     DEFAULT_LINKS,
+    DEFAULT_ACCOUNT_STATE,
 )
 
 
@@ -380,6 +381,82 @@ class TestValidationMessagesPlannatechErrorTypes:
         state), unlike the other infra types."""
         validation = ValidationMessages(session_expired=MessageItem(text="Sign in again"))
         assert validation.session_expired.text == "Sign in again"
+
+
+class TestValidationMessagesAccountStateDefaults:
+    """Validate the localized `account_state_defaults` fallback added under
+    ValidationMessages for SDD change `plannatech-errortype-mapping`.
+
+    Mirrors the `ErrorMessages.general_errors` strategy: a module-level constant
+    (`DEFAULT_ACCOUNT_STATE`) auto-fills via `default_factory` on the constructor
+    and on `model_validate`, even when the Dynamo item omits the key, so the
+    consumer always has a multi-language fallback. Shape: action -> {lang -> text}.
+    Operators override the per-action copy via the per-field MessageItem templates."""
+
+    ACTIONS = [
+        "account_blocked",
+        "unauthorized_user",
+        "user_not_found",
+        "self_excluded",
+        "terms_not_accepted",
+        "terms_version_outdated",
+        "otp_attempts_exceeded",
+        "two_factor_inactive",
+        "betting_time_expired",
+        "session_expired",
+        "account_blocked_by_request",
+    ]
+    LANGS = {"es", "en", "pt-br"}
+
+    def test_defaults_with_direct_constructor(self):
+        validation = ValidationMessages()
+        assert validation.account_state_defaults is not None
+        assert set(validation.account_state_defaults.keys()) == set(self.ACTIONS)
+
+    @pytest.mark.parametrize("action", ACTIONS)
+    def test_each_action_has_all_three_languages(self, action):
+        validation = ValidationMessages()
+        langs = validation.account_state_defaults[action]
+        assert set(langs.keys()) == self.LANGS
+        for lang in self.LANGS:
+            assert isinstance(langs[lang], str) and langs[lang].strip()
+
+    def test_defaults_when_not_provided_via_model_validate(self):
+        """A DDB item WITHOUT account_state_defaults still gets the full default."""
+        validation = ValidationMessages.model_validate({"member_validation": "hello"})
+        assert validation.member_validation.text == "hello"
+        assert set(validation.account_state_defaults.keys()) == set(self.ACTIONS)
+        for action in self.ACTIONS:
+            assert set(validation.account_state_defaults[action].keys()) == self.LANGS
+
+    def test_factory_returns_constant_content(self):
+        validation = ValidationMessages()
+        assert validation.account_state_defaults == DEFAULT_ACCOUNT_STATE
+
+    def test_from_minimal_populates_account_state_defaults(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.validation is not None
+        defaults = templates.validation.account_state_defaults
+        assert set(defaults.keys()) == set(self.ACTIONS)
+        for action in self.ACTIONS:
+            assert set(defaults[action].keys()) == self.LANGS
+
+    def test_account_state_defaults_in_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "validation" in item
+        assert "account_state_defaults" in item["validation"]
+        assert set(item["validation"]["account_state_defaults"].keys()) == set(
+            self.ACTIONS
+        )
+
+    def test_operator_can_override_via_model_validate(self):
+        """Providing account_state_defaults explicitly replaces the default."""
+        custom = {"account_blocked": {"es": "x", "en": "y", "pt-br": "z"}}
+        validation = ValidationMessages.model_validate(
+            {"account_state_defaults": custom}
+        )
+        assert validation.account_state_defaults == custom
 
 
 class TestBetsMessagesPlannatechErrorTypes:


### PR DESCRIPTION
Cherry-pick of #158 to staging.

Adds `DEFAULT_ACCOUNT_STATE` + `ValidationMessages.account_state_defaults` (default_factory, multi-language es/en/pt-br) — localized fallbacks for Plannatech account-state errorTypes, mirroring the `DEFAULT_GENERAL_ERRORS` pattern.

**Must merge before** the channel-services staging PR that renders these defaults (otherwise the operator-template tier is inert in staging; render is defensive, no crash).

Refs ClickUp 86aj2wm7y. Original: #158 (merged to develop).