### PR TITLE
feat(locale): add default_minimum_odds field to LocaleConfig

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -306,6 +306,7 @@ class LocaleConfig(BaseModel):
     time_zone: str
     default_amount: Optional[str] = None
     default_desired_profit: Optional[str] = None
+    default_minimum_odds: Optional[str] = None
 
     @field_validator("currency")
     @classmethod
@@ -419,6 +420,7 @@ class SiteConfig(BaseModel):
             time_zone="UTC",
             default_amount="",
             default_desired_profit="",
+            default_minimum_odds="",
         )
     )
     features: FeaturesConfig = Field(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `default_minimum_odds` configuration option to site locale settings. Administrators can now specify minimum odds defaults on a per-locale basis for enhanced control over betting configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->