### PR TITLE
feat(templates): add add_to_combo_offer message template key

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -384,6 +384,13 @@ class BetsMessages(BaseModel):
     bet_rejected: Optional[MessageItem] = None
     bet_rejected_duplicate: Optional[MessageItem] = None
     select_type_of_bet: Optional[MessageItem] = None
+    # Dedicated template for the betslip "Add to a combo" follow-up bubble.
+    # See SDD change `add-to-combo-offer-dedicated-key`. `.text` is the bubble
+    # prompt; `reply_markup` carries a SINGLE button whose `.text` is the button
+    # label. The button's `callback_data` here is only a placeholder — the real
+    # callback is injected by the consuming app's code, so no callback validator
+    # is attached to this field.
+    add_to_combo_offer: Optional[MessageItem] = None
     closed_fixture: Optional[MessageItem] = None
     # Plannatech errorType -> operator-configurable business-facing bet UX.
     # See SDD change `plannatech-errortype-mapping`. InsufficientBalance reuses
@@ -1138,6 +1145,19 @@ class MessageTemplates(BaseModel):
                                 InlineKeyboardButton(
                                     text="Combo",
                                     callback_data="add_market_to_combo&{FIXTURE_ID}",
+                                ),
+                            ]
+                        ]
+                    ),
+                ),
+                add_to_combo_offer=MessageItem(
+                    text="Want to turn this into a combo? Add this pick as the first leg.",
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="➕ Add to a combo",
+                                    callback_data="add_to_combo",
                                 ),
                             ]
                         ]

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -563,6 +563,63 @@ class TestBetsMessages:
         assert bets.select_sport.text == "Select sport"
         assert bets.bet_amount.text == "Enter amount"
 
+    def test_add_to_combo_offer_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.add_to_combo_offer is None
+
+    def test_add_to_combo_offer_accepts_message_item(self):
+        bets = BetsMessages(
+            add_to_combo_offer=MessageItem(
+                text="Add this pick as the first leg.",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="➕ Add to a combo",
+                                callback_data="add_to_combo",
+                            ),
+                        ]
+                    ]
+                ),
+            )
+        )
+        assert bets.add_to_combo_offer.text == "Add this pick as the first leg."
+        button = bets.add_to_combo_offer.reply_markup.inline_keyboard[0][0]
+        assert button.text == "➕ Add to a combo"
+        # callback_data is a code-injected placeholder; no validator enforced.
+        assert button.callback_data == "add_to_combo"
+
+    def test_add_to_combo_offer_from_minimal(self):
+        templates = MessageTemplates.from_minimal()
+        offer = templates.bets.add_to_combo_offer
+        assert offer is not None
+        assert offer.text == (
+            "Want to turn this into a combo? Add this pick as the first leg."
+        )
+        button = offer.reply_markup.inline_keyboard[0][0]
+        assert button.text == "➕ Add to a combo"
+        assert button.callback_data == "add_to_combo"
+
+    def test_add_to_combo_offer_round_trips_through_serialization(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "add_to_combo_offer" in item["bets"]
+        offer = item["bets"]["add_to_combo_offer"]
+        assert offer["text"] == (
+            "Want to turn this into a combo? Add this pick as the first leg."
+        )
+        button = offer["reply_markup"]["inline_keyboard"][0][0]
+        assert button["text"] == "➕ Add to a combo"
+        assert button["callback_data"] == "add_to_combo"
+
+        # Deserialize back and confirm the field survives the round-trip.
+        restored = BetsMessages.model_validate(item["bets"])
+        assert restored.add_to_combo_offer is not None
+        assert (
+            restored.add_to_combo_offer.reply_markup.inline_keyboard[0][0].text
+            == "➕ Add to a combo"
+        )
+
 
 class TestBetsMessagesLiveDisclaimer:
     """Validate the `live_disclaimer` template added under BetsMessages.


### PR DESCRIPTION
## What
Adds a new `add_to_combo_offer: Optional[MessageItem] = None` field to `BetsMessages`, sibling to `select_type_of_bet`. It is the dedicated template for the betslip "Add to a combo" follow-up bubble: `.text` is the bubble prompt and `reply_markup` carries a SINGLE button whose `.text` is the button label.

Also seeds a sensible default in `MessageTemplates.from_minimal()` (prompt + single inline button "➕ Add to a combo").

## Why
Replaces the prior approach of reusing `bets.select_type_of_bet` for the "Add to a combo" bubble, which confused Backoffice operators (it surfaced a dead screen's template). A dedicated, clearly-named key lets operators edit this bubble independently.

## Notes
- The field is **Optional** and has **no callback validator** — the real callback is injected by the consuming app's code, so the button's `callback_data` in the template is only a placeholder (`add_to_combo`).
- The existing `select_type_of_bet` validators are untouched.
- Round-trips through `MessageTemplatesDB` / `to_dynamodb_item()` automatically (shared model via inheritance).

## Tests
Added 4 tests under `TestBetsMessages`: accepts a `MessageItem`, defaults to `None`, is seeded by `from_minimal()`, and serializes/deserializes (DynamoDB round-trip). Full suite: 431 passed, coverage 92.34% (gate 80%).

## Cross-repo
Step 1 of `add-to-combo-offer-dedicated-key`. base-models must land per-env AHEAD of consumers. Consumed next by **bet-bot** (read `bets.add_to_combo_offer` for prompt + button label) and **backoffice** (expose new key, hide `select_type_of_bet`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new betslip message template for the “Add to a combo” follow-up bubble.
  * Included a default localized prompt and a single “➕ Add to a combo” button in the minimal template setup.

* **Tests**
  * Expanded coverage to verify the new template field’s default behavior, button details, and data persistence across serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->