### PR TITLE
fix(templates): drop required-callbacks validator on select_type_of_bet

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -404,29 +404,11 @@ class BetsMessages(BaseModel):
     # (winning, not stake) per SDD change `betcris-minimum-win-message`.
     minimum_potential_winning: Optional[MessageItem] = None
 
-    @field_validator("select_type_of_bet")
-    @classmethod
-    def _type_of_bet_rules(cls, v):
-        return require_callbacks(
-            v, ["bet_simple&{FIXTURE_ID}", "add_market_to_combo&{FIXTURE_ID}"]
-        )
-
     @classmethod
     def model_validate(cls, obj):
         if isinstance(obj, dict):
             obj = {k: MessageItem._coerce(v) for k, v in obj.items()}
         return super().model_validate(obj)
-
-    @model_validator(mode="after")
-    def _require_callbacks(self):
-        if self.select_type_of_bet is None:
-            return self
-        need = {"bet_simple&{FIXTURE_ID}", "add_market_to_combo&{FIXTURE_ID}"}
-        got = extract(self.select_type_of_bet)
-        missing = need - got
-        if missing:
-            raise ValueError(f"select_type_of_bet missing callbacks: {sorted(missing)}")
-        return self
 
 
 class CombosMessages(BaseModel):

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -567,6 +567,36 @@ class TestBetsMessages:
         bets = BetsMessages()
         assert bets.add_to_combo_offer is None
 
+    def test_select_type_of_bet_accepts_item_without_required_callbacks(self):
+        # The select_type_of_bet screen is unreachable dead code (rerouted by
+        # CU-86aj6gpa1) and no runtime reads its callbacks. Operators must be
+        # free to delete/rename its buttons from the Backoffice, so the field
+        # no longer requires the bet_simple/add_market_to_combo callbacks.
+        bets = BetsMessages(
+            select_type_of_bet=MessageItem(
+                text="Pick a bet type",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="Only one button now",
+                                callback_data="some_other_callback",
+                            ),
+                        ]
+                    ]
+                ),
+            )
+        )
+        button = bets.select_type_of_bet.reply_markup.inline_keyboard[0][0]
+        assert button.callback_data == "some_other_callback"
+
+    def test_select_type_of_bet_accepts_item_without_buttons(self):
+        # Operator may strip the keyboard entirely; this must not raise.
+        bets = BetsMessages(
+            select_type_of_bet=MessageItem(text="Pick a bet type"),
+        )
+        assert bets.select_type_of_bet.text == "Pick a bet type"
+
     def test_add_to_combo_offer_accepts_message_item(self):
         bets = BetsMessages(
             add_to_combo_offer=MessageItem(


### PR DESCRIPTION
The validator forced `select_type_of_bet` to keep the `bet_simple&{FIXTURE_ID}` and `add_market_to_combo&{FIXTURE_ID}` callbacks, blocking operators from deleting or modifying those buttons in the Backoffice.

The `select_type_of_bet` screen is unreachable dead code (rerouted by CU-86aj6gpa1) and no runtime code reads those callbacks, so the rule is safe to remove.

## Changes
- Removed the `@field_validator("select_type_of_bet")` (`_type_of_bet_rules`) and the `@model_validator(mode="after")` (`_require_callbacks`) from `BetsMessages`. The model_validator only checked `select_type_of_bet`, so it was removed entirely.
- Field stays `select_type_of_bet: Optional[MessageItem] = None`, now unconstrained.
- `require_callbacks`/`extract` helpers kept (other validators use them); other field validators untouched.

## Tests
- Added two tests: `select_type_of_bet` accepts a `MessageItem` without the required callbacks, and accepts one with no keyboard at all.
- Full suite: 433 passed, coverage 92.34% (>= 80% threshold).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed message validation so bet selection content can be saved even when optional callback buttons are missing or use different callback data.
  * Preserved the displayed text and button details when present, without blocking updates from the backoffice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->