### PR TITLE
chore(staging): promote add_to_combo_offer field + relax select_type_of_bet validator

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -384,6 +384,13 @@ class BetsMessages(BaseModel):
     bet_rejected: Optional[MessageItem] = None
     bet_rejected_duplicate: Optional[MessageItem] = None
     select_type_of_bet: Optional[MessageItem] = None
+    # Dedicated template for the betslip "Add to a combo" follow-up bubble.
+    # See SDD change `add-to-combo-offer-dedicated-key`. `.text` is the bubble
+    # prompt; `reply_markup` carries a SINGLE button whose `.text` is the button
+    # label. The button's `callback_data` here is only a placeholder — the real
+    # callback is injected by the consuming app's code, so no callback validator
+    # is attached to this field.
+    add_to_combo_offer: Optional[MessageItem] = None
     closed_fixture: Optional[MessageItem] = None
     # Plannatech errorType -> operator-configurable business-facing bet UX.
     # See SDD change `plannatech-errortype-mapping`. InsufficientBalance reuses
@@ -1138,6 +1145,19 @@ class MessageTemplates(BaseModel):
                                 InlineKeyboardButton(
                                     text="Combo",
                                     callback_data="add_market_to_combo&{FIXTURE_ID}",
+                                ),
+                            ]
+                        ]
+                    ),
+                ),
+                add_to_combo_offer=MessageItem(
+                    text="Want to turn this into a combo? Add this pick as the first leg.",
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="➕ Add to a combo",
+                                    callback_data="add_to_combo",
                                 ),
                             ]
                         ]

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -404,29 +404,11 @@ class BetsMessages(BaseModel):
     # (winning, not stake) per SDD change `betcris-minimum-win-message`.
     minimum_potential_winning: Optional[MessageItem] = None
 
-    @field_validator("select_type_of_bet")
-    @classmethod
-    def _type_of_bet_rules(cls, v):
-        return require_callbacks(
-            v, ["bet_simple&{FIXTURE_ID}", "add_market_to_combo&{FIXTURE_ID}"]
-        )
-
     @classmethod
     def model_validate(cls, obj):
         if isinstance(obj, dict):
             obj = {k: MessageItem._coerce(v) for k, v in obj.items()}
         return super().model_validate(obj)
-
-    @model_validator(mode="after")
-    def _require_callbacks(self):
-        if self.select_type_of_bet is None:
-            return self
-        need = {"bet_simple&{FIXTURE_ID}", "add_market_to_combo&{FIXTURE_ID}"}
-        got = extract(self.select_type_of_bet)
-        missing = need - got
-        if missing:
-            raise ValueError(f"select_type_of_bet missing callbacks: {sorted(missing)}")
-        return self
 
 
 class CombosMessages(BaseModel):

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -563,6 +563,63 @@ class TestBetsMessages:
         assert bets.select_sport.text == "Select sport"
         assert bets.bet_amount.text == "Enter amount"
 
+    def test_add_to_combo_offer_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.add_to_combo_offer is None
+
+    def test_add_to_combo_offer_accepts_message_item(self):
+        bets = BetsMessages(
+            add_to_combo_offer=MessageItem(
+                text="Add this pick as the first leg.",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="➕ Add to a combo",
+                                callback_data="add_to_combo",
+                            ),
+                        ]
+                    ]
+                ),
+            )
+        )
+        assert bets.add_to_combo_offer.text == "Add this pick as the first leg."
+        button = bets.add_to_combo_offer.reply_markup.inline_keyboard[0][0]
+        assert button.text == "➕ Add to a combo"
+        # callback_data is a code-injected placeholder; no validator enforced.
+        assert button.callback_data == "add_to_combo"
+
+    def test_add_to_combo_offer_from_minimal(self):
+        templates = MessageTemplates.from_minimal()
+        offer = templates.bets.add_to_combo_offer
+        assert offer is not None
+        assert offer.text == (
+            "Want to turn this into a combo? Add this pick as the first leg."
+        )
+        button = offer.reply_markup.inline_keyboard[0][0]
+        assert button.text == "➕ Add to a combo"
+        assert button.callback_data == "add_to_combo"
+
+    def test_add_to_combo_offer_round_trips_through_serialization(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "add_to_combo_offer" in item["bets"]
+        offer = item["bets"]["add_to_combo_offer"]
+        assert offer["text"] == (
+            "Want to turn this into a combo? Add this pick as the first leg."
+        )
+        button = offer["reply_markup"]["inline_keyboard"][0][0]
+        assert button["text"] == "➕ Add to a combo"
+        assert button["callback_data"] == "add_to_combo"
+
+        # Deserialize back and confirm the field survives the round-trip.
+        restored = BetsMessages.model_validate(item["bets"])
+        assert restored.add_to_combo_offer is not None
+        assert (
+            restored.add_to_combo_offer.reply_markup.inline_keyboard[0][0].text
+            == "➕ Add to a combo"
+        )
+
 
 class TestBetsMessagesLiveDisclaimer:
     """Validate the `live_disclaimer` template added under BetsMessages.

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -567,6 +567,36 @@ class TestBetsMessages:
         bets = BetsMessages()
         assert bets.add_to_combo_offer is None
 
+    def test_select_type_of_bet_accepts_item_without_required_callbacks(self):
+        # The select_type_of_bet screen is unreachable dead code (rerouted by
+        # CU-86aj6gpa1) and no runtime reads its callbacks. Operators must be
+        # free to delete/rename its buttons from the Backoffice, so the field
+        # no longer requires the bet_simple/add_market_to_combo callbacks.
+        bets = BetsMessages(
+            select_type_of_bet=MessageItem(
+                text="Pick a bet type",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="Only one button now",
+                                callback_data="some_other_callback",
+                            ),
+                        ]
+                    ]
+                ),
+            )
+        )
+        button = bets.select_type_of_bet.reply_markup.inline_keyboard[0][0]
+        assert button.callback_data == "some_other_callback"
+
+    def test_select_type_of_bet_accepts_item_without_buttons(self):
+        # Operator may strip the keyboard entirely; this must not raise.
+        bets = BetsMessages(
+            select_type_of_bet=MessageItem(text="Pick a bet type"),
+        )
+        assert bets.select_type_of_bet.text == "Pick a bet type"
+
     def test_add_to_combo_offer_accepts_message_item(self):
         bets = BetsMessages(
             add_to_combo_offer=MessageItem(


### PR DESCRIPTION
Cherry-picks #167 + #168 to staging.

- #167: adds `add_to_combo_offer` field to `BetsMessages` + from_minimal seed + tests (1cb312f).
- #168: removes the required-callbacks validator on `select_type_of_bet` + tests (880a9e3).

Net state of message_template.py and test_message_template.py matches develop exactly. Full suite: 433 passed, 92% coverage.

Must merge BEFORE channel-services & backoffice staging PRs (they build base-models@staging).