### PR TITLE
feat(personality): allow bot_name to be empty

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -244,7 +244,7 @@ def _reject_html(value: str, field: str) -> str:
 
 class PersonalityConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    bot_name: str = Field(default="ChatBet", min_length=2, max_length=20)
+    bot_name: str = Field(default="", max_length=20)
     formality_level: int = Field(default=2, ge=1, le=5)
     emoji_level: int = Field(default=2, ge=1, le=3)
     response_length: int = Field(default=1, ge=1, le=3)

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -29,6 +29,7 @@ from chatbet_base_models.site_config_model import (
     AuthConfig,
     SiteConfig,
     SiteConfigDB,
+    PersonalityConfig,
 )
 
 
@@ -366,6 +367,28 @@ class TestIdentity:
     def test_invalid_url_raises_error(self):
         with pytest.raises(ValueError):
             Identity(site_name="ChatBet", company_id="chatbet123", site_url="not-a-url")
+
+
+class TestPersonalityConfig:
+    def test_default_bot_name_is_empty(self):
+        personality = PersonalityConfig()
+        assert personality.bot_name == ""
+
+    def test_accepts_empty_bot_name(self):
+        personality = PersonalityConfig(bot_name="")
+        assert personality.bot_name == ""
+
+    def test_accepts_single_char_bot_name(self):
+        personality = PersonalityConfig(bot_name="X")
+        assert personality.bot_name == "X"
+
+    def test_rejects_bot_name_over_max_length(self):
+        with pytest.raises(ValidationError):
+            PersonalityConfig(bot_name="x" * 21)
+
+    def test_rejects_html_in_bot_name(self):
+        with pytest.raises(ValueError):
+            PersonalityConfig(bot_name="<script>alert(1)</script>")
 
 
 class TestLocaleConfig:


### PR DESCRIPTION
Meta/WhatsApp gambling policy requires greeting without naming the brand. Removes min_length=2 and changes the default away from "ChatBet" so the LLM can present itself generically when bot_name is blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the bot name setting to allow empty or single-character values while still blocking overly long names.
  - Preserved protection against HTML/script content in bot name input.

- **Tests**
  - Added coverage for the updated bot name behavior, including default value, length validation, and content validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->