### PR TITLE
feat(validation): add BO-editable confirm_phone_number template

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -247,6 +247,14 @@ class ValidationMessages(BaseModel):
     error_otp: Optional[MessageItem] = None
     blocked_otp: Optional[MessageItem] = None
     blocked_user: Optional[MessageItem] = None
+    # BO-editable override for the WhatsApp detected-number login confirm
+    # screen. See SDD change `whatsapp-detected-number-login`. The prompt
+    # supports a `{phone}` placeholder (the detected/masked sender number) and
+    # carries two buttons with callbacks `use_detected_phone` (use this number)
+    # and `change_account_otp` (change number). When absent, bet-bot falls back
+    # to hardcoded localized defaults (account_state_defaults pattern), so empty
+    # configs are safe.
+    confirm_phone_number: Optional[MessageItem] = None
     # Plannatech `terms_not_accepted` (Result=-1219) signaling.
     # See SDD change `terms-not-accepted`.
     terms_not_accepted: Optional[MessageItem] = None
@@ -307,6 +315,11 @@ class ValidationMessages(BaseModel):
     def _error_otp_rules(cls, v):
         return require_callbacks(v, ["send_otp"])
 
+    @field_validator("confirm_phone_number")
+    @classmethod
+    def _confirm_phone_number_rules(cls, v):
+        return require_callbacks(v, ["use_detected_phone", "change_account_otp"])
+
     @model_validator(mode="after")
     def _require_callbacks(self):
         need = {"send_otp"}
@@ -321,6 +334,14 @@ class ValidationMessages(BaseModel):
             missing = need - got
             if missing:
                 raise ValueError(f"{field} missing callbacks: {sorted(missing)}")
+        if self.confirm_phone_number is not None:
+            need_confirm = {"use_detected_phone", "change_account_otp"}
+            got = extract(self.confirm_phone_number)
+            missing = need_confirm - got
+            if missing:
+                raise ValueError(
+                    f"confirm_phone_number missing callbacks: {sorted(missing)}"
+                )
         return self
 
 

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -261,6 +261,140 @@ class TestValidationMessagesPasswordTemplates:
             )
 
 
+def _confirm_phone_item(text="¿Ingresar con este número?"):
+    """Helper: a valid `confirm_phone_number` MessageItem carrying both
+    required callbacks (`use_detected_phone` + `change_account_otp`)."""
+    return MessageItem(
+        text=text,
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text="✅ Usar este número",
+                        callback_data="use_detected_phone",
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        text="✏️ Cambiar número",
+                        callback_data="change_account_otp",
+                    )
+                ],
+            ]
+        ),
+    )
+
+
+class TestValidationMessagesConfirmPhoneNumber:
+    """Validate the `confirm_phone_number` template added under ValidationMessages.
+
+    See SDD change `whatsapp-detected-number-login`. BO-editable override for the
+    WhatsApp detected-number login confirm screen: a prompt (supporting a
+    `{phone}` placeholder) plus two buttons carrying callbacks
+    `use_detected_phone` and `change_account_otp`. The field is
+    `Optional[MessageItem] = None` so existing company configs that omit it keep
+    validating; bet-bot falls back to hardcoded localized defaults when absent."""
+
+    def test_confirm_phone_number_defaults_to_none(self):
+        validation = ValidationMessages()
+        assert validation.confirm_phone_number is None
+
+    def test_confirm_phone_number_omitted_from_dict_yields_none(self):
+        validation = ValidationMessages.model_validate(
+            {"member_validation": "Please validate"}
+        )
+        assert validation.confirm_phone_number is None
+        assert validation.member_validation.text == "Please validate"
+
+    def test_confirm_phone_number_with_both_callbacks_validates(self):
+        validation = ValidationMessages(confirm_phone_number=_confirm_phone_item())
+        assert validation.confirm_phone_number is not None
+        got = {
+            btn.callback_data
+            for row in validation.confirm_phone_number.reply_markup.inline_keyboard
+            for btn in row
+        }
+        assert got == {"use_detected_phone", "change_account_otp"}
+
+    def test_confirm_phone_number_missing_callbacks_raises(self):
+        """Provided but WITHOUT the required callbacks must raise."""
+        with pytest.raises(ValueError):
+            ValidationMessages(
+                confirm_phone_number=MessageItem(
+                    text="¿Ingresar con este número?",
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="✅ Usar este número",
+                                    callback_data="use_detected_phone",
+                                )
+                            ]
+                            # missing `change_account_otp`
+                        ]
+                    ),
+                )
+            )
+
+    def test_confirm_phone_number_without_keyboard_raises(self):
+        """A plain-text item (no inline keyboard at all) must raise."""
+        with pytest.raises(ValueError):
+            ValidationMessages(
+                confirm_phone_number=MessageItem(text="¿Ingresar con este número?")
+            )
+
+    def test_confirm_phone_number_round_trip_via_model_validate_and_dump(self):
+        data = {
+            "confirm_phone_number": {
+                "text": "Detectamos que escribís desde {phone}. ¿Ingresar?",
+                "reply_markup": {
+                    "inline_keyboard": [
+                        [
+                            {
+                                "text": "✅ Usar este número",
+                                "callback_data": "use_detected_phone",
+                            }
+                        ],
+                        [
+                            {
+                                "text": "✏️ Cambiar número",
+                                "callback_data": "change_account_otp",
+                            }
+                        ],
+                    ]
+                },
+            }
+        }
+        validation = ValidationMessages.model_validate(data)
+        assert "{phone}" in validation.confirm_phone_number.text
+
+        dumped = validation.model_dump(exclude_none=True)
+        assert "confirm_phone_number" in dumped
+        reloaded = ValidationMessages.model_validate(dumped)
+        assert reloaded.confirm_phone_number.text == validation.confirm_phone_number.text
+
+    def test_confirm_phone_number_serializes_in_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        templates.validation.confirm_phone_number = _confirm_phone_item()
+        item = templates.to_dynamodb_item()
+        assert "confirm_phone_number" in item["validation"]
+        cbs = {
+            btn["callback_data"]
+            for row in item["validation"]["confirm_phone_number"]["reply_markup"][
+                "inline_keyboard"
+            ]
+            for btn in row
+        }
+        assert cbs == {"use_detected_phone", "change_account_otp"}
+
+    def test_confirm_phone_number_unknown_key_rejected(self):
+        """`extra=forbid` keeps protecting against typos near the new field."""
+        with pytest.raises(ValidationError):
+            ValidationMessages.model_validate(
+                {"confirm_phone_numbr": {"text": "typo"}}
+            )
+
+
 class TestValidationMessagesTermsNotAccepted:
     """Validate the `terms_not_accepted` template added under ValidationMessages.
 


### PR DESCRIPTION
## What

Adds a new BO-editable field `validation.confirm_phone_number` (`Optional[MessageItem] = None`) to `ValidationMessages`.

It carries:
- a **prompt** supporting a `{phone}` placeholder (the detected/masked sender number), and
- **two buttons** with callbacks `use_detected_phone` (use this number) and `change_account_otp` (change number).

Callback enforcement mirrors `send_otp`: a `@field_validator` + the `_require_callbacks` model validator require both callbacks **only when the field is provided**.

## Why

Unblocks Backoffice editing of the **WhatsApp detected-number login confirm screen** (SDD change `whatsapp-detected-number-login`). Today bet-bot renders that screen from hardcoded i18n defaults; this field lets operators override the copy per company.

## Compatibility

- Field is `Optional = None` and **not** added to `from_minimal()`, so existing company configs that omit it keep validating under `extra="forbid"` — no migration required.
- Consumers (bet-bot) read it via a **defensive `getattr` fallback**, so this is **non-breaking**: runtime stays safe even on a base-models version that predates the field.

## Merge order

Per the **base-models-before-consumers** convention, this should merge **FIRST per environment** so the bet-bot consumer and the per-company DynamoDB template text can follow.

## Tests

`tests/test_message_template.py` — `TestValidationMessagesConfirmPhoneNumber`: default `None`, dict round-trip, `{phone}` placeholder preserved, DynamoDB serialization, `extra=forbid` typo rejection, and ValueError when required callbacks are missing / no keyboard. Full suite: 435 passed, 93% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a phone-number confirmation screen with required action buttons.
  * Added a new configurable message for bets that are below the minimum potential winnings threshold.

* **Bug Fixes**
  * Improved validation so message configurations reject missing or incomplete button setups.
  * Ensured new message fields round-trip correctly through saved and loaded templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->