### PR TITLE
feat(features): add whatsapp_detected_login feature flag

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -350,6 +350,10 @@ class FeaturesConfig(BaseModel):
         default=False,
         description="Enable or disable live in this configuration",
     )
+    whatsapp_detected_login: Optional[bool] = Field(
+        default=False,
+        description="Enable WhatsApp detected-number login confirm screen (per-company rollout). When False, WhatsApp users keep the type-the-number flow.",
+    )
     fixture_range_days: Optional[int] = Field(
         default=7,
         ge=1,
@@ -435,6 +439,7 @@ class SiteConfig(BaseModel):
             hour_format=HourFormat.H24,
             skip_pre_auth_validation=False,
             live=False,
+            whatsapp_detected_login=False,
             fixture_range_days=7,
         )
     )

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -520,6 +520,44 @@ class TestFeaturesConfig:
                     fixture_range_days=invalid,
                 )
 
+    def test_features_config_default_whatsapp_detected_login(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+        )
+        assert features.whatsapp_detected_login is False
+
+    def test_features_config_whatsapp_detected_login_enabled(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+            whatsapp_detected_login=True,
+        )
+        assert features.whatsapp_detected_login is True
+
+    def test_features_config_whatsapp_detected_login_round_trip(self):
+        features = FeaturesConfig.model_validate(
+            {
+                "odd_type": OddType.DECIMAL,
+                "validation": ValidationMethod.EMAIL,
+                "combos": True,
+                "chatbet_version": ChatbetVersion.V2,
+                "multigames_response": True,
+                "see_in_combo": True,
+                "whatsapp_detected_login": True,
+            }
+        )
+        assert features.whatsapp_detected_login is True
+        assert features.model_dump()["whatsapp_detected_login"] is True
+
 
 class TestMeta:
     def test_create_meta_with_defaults(self):


### PR DESCRIPTION
## What

Adds a per-company `features.whatsapp_detected_login` boolean flag (default `False`) to `FeaturesConfig`, to gate the WhatsApp detected-number login confirm screen.

## Why

Enables a gradual, per-company rollout of the WhatsApp detected-number login flow (initially only company `chatbeten`). The consumer (channel-services) reads this flag defensively via `getattr(config.site_config.features, "whatsapp_detected_login", False)` and falls back to the legacy type-the-number flow when the flag is `False` or absent.

## Non-breaking

Default `False` means every existing company keeps its current behavior until the flag is explicitly enabled in their DynamoDB `site_config`. Added to the `SiteConfig.features` `default_factory` alongside `combos`/`live` for consistency.

## Tests

Added 3 tests in `TestFeaturesConfig` (default-False, explicit-True, dict round-trip). Full suite: 449 passed, coverage 93% total / 96% for `site_config_model.py` (gate 80%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional WhatsApp login setting to site configuration, letting the detected-number confirmation screen be turned on or off.
  * The new setting defaults to **off** for existing and new configurations.

* **Tests**
  * Added coverage to confirm the new setting’s default behavior, explicit enabled state, and сохранение across validation and export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->