### PR TITLE
feat(message-template): seed confirm_phone_number default in from_minimal

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -1067,6 +1067,28 @@ class MessageTemplates(BaseModel):
                 blocked_user=MessageItem(
                     text="Sorry, I can't help you, you are blocked",
                 ),
+                confirm_phone_number=MessageItem(
+                    text=(
+                        "Detectamos que nos escribís desde {phone}.\n"
+                        "¿Querés ingresar con este número?"
+                    ),
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="✅ Usar este número",
+                                    callback_data="use_detected_phone",
+                                )
+                            ],
+                            [
+                                InlineKeyboardButton(
+                                    text="✏️ Cambiar número",
+                                    callback_data="change_account_otp",
+                                )
+                            ],
+                        ]
+                    ),
+                ),
                 password_required=MessageItem(
                     text="Para continuar, completá el formulario rápido 👇",
                 ),

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -387,6 +387,26 @@ class TestValidationMessagesConfirmPhoneNumber:
         }
         assert cbs == {"use_detected_phone", "change_account_otp"}
 
+    def test_from_minimal_seeds_confirm_phone_number(self):
+        """`from_minimal()` auto-seeds a valid `confirm_phone_number` so NEW
+        companies get an editable WhatsApp detected-number login confirm
+        template out of the box (existing companies covered by the
+        channel-services migration)."""
+        templates = MessageTemplates.from_minimal()
+        item = templates.validation.confirm_phone_number
+        assert item is not None
+        # Prompt carries the {phone} placeholder the renderer substitutes.
+        assert "{phone}" in item.text
+        # Exactly two rows, one button each, with the required BARE callbacks
+        # (no `oi:`/`ai:` prefix).
+        rows = item.reply_markup.inline_keyboard
+        assert len(rows) == 2
+        assert all(len(row) == 1 for row in rows)
+        assert rows[0][0].callback_data == "use_detected_phone"
+        assert rows[1][0].callback_data == "change_account_otp"
+        # The whole container re-validates (field + model validators pass).
+        MessageTemplates.model_validate(templates.model_dump())
+
     def test_confirm_phone_number_unknown_key_rejected(self):
         """`extra=forbid` keeps protecting against typos near the new field."""
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## What

`MessageTemplates.from_minimal()` now auto-seeds a valid `confirm_phone_number` template under `ValidationMessages`, so NEW companies get an editable WhatsApp detected-number login confirm screen out of the box.

- `text`: prompt with a `{phone}` placeholder the renderer substitutes with the detected/masked sender number.
- `reply_markup.inline_keyboard`: two rows, one button each — row 1 "✅ Usar este número" (`callback_data="use_detected_phone"`), row 2 "✏️ Cambiar número" (`callback_data="change_account_otp"`).
- Callbacks are BARE strings (no `oi:`/`ai:` prefix), matching the field validators that require `use_detected_phone` + `change_account_otp`.

Existing companies are covered by the channel-services migration; this only affects freshly-created configs.

## Tests

Extended `TestValidationMessagesConfirmPhoneNumber` with `test_from_minimal_seeds_confirm_phone_number`, asserting the two correct bare callbacks and that the full container re-validates. Full suite: 450 passed, coverage 93% (gate is 80%).

## Related PRs

- chatbet-backoffice #686
- channel-services #808

## Note

base-models must merge FIRST per env (base-models-before-consumers) — matches the existing convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new default phone-number confirmation message in the validation flow.
  * Users can now choose to use the detected phone number or switch to a different one directly from the prompt.
  
* **Tests**
  * Added coverage to ensure the new phone confirmation message is included by default and remains valid when saved and reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->