### PR TITLE
feat(message-template): add account_frozen and non_combinable_selection bet-rejection templates

### DIFF
--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # Message Templates
 from .message_template import (

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -424,6 +424,11 @@ class BetsMessages(BaseModel):
     # stake*odds >= min) -> operator-configurable copy. Semantic field name
     # (winning, not stake) per SDD change `betcris-minimum-win-message`.
     minimum_potential_winning: Optional[MessageItem] = None
+    # iSolutions -32 errorTypes -> operator-configurable business-facing bet UX.
+    # `account_frozen` maps to `AccountFrozen`; `non_combinable_selection` maps
+    # to `NonCombinableSelection`. Companion to sportbook-services PRs #589/#626.
+    account_frozen: Optional[MessageItem] = None
+    non_combinable_selection: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.0"
+version = "1.0.1"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -625,6 +625,8 @@ class TestBetsMessagesPlannatechErrorTypes:
         "bet_limit_exceeded",
         "bet_amount_too_low",
         "minimum_potential_winning",
+        "account_frozen",
+        "non_combinable_selection",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)


### PR DESCRIPTION
## Summary

Adds **two** new operator-editable bet-rejection message templates to the `BetsMessages` Pydantic model, following the exact pattern of the existing Plannatech/iSolutions error-type fields:

- `account_frozen: Optional[MessageItem] = None` — maps to iSolutions -32 errorType `AccountFrozen`
- `non_combinable_selection: Optional[MessageItem] = None` — maps to iSolutions -32 errorType `NonCombinableSelection`

Both are optional, default to `None`, and are operator-configurable via the backoffice. Because `BetsMessages` uses `ConfigDict(extra="forbid")`, declaring these fields is what makes the backoffice PUT accept them.

> Note: `market_unavailable` already existed — it was **not** re-added.

Companion to sportbook-services PRs **#589 / #626**. Part of ClickUp **86aj0z29w**.

## Changes

- `chatbet_base_models/message_template.py` — 2 new fields on `BetsMessages` with a grouping comment noting the iSolutions -32 errorType mapping.
- `tests/test_message_template.py` — added both fields to `TestBetsMessagesPlannatechErrorTypes.NEW_FIELDS`, covering default-`None` and round-trip/string-coercion.
- Version bump `1.0.0` → `1.0.1` (PATCH — adding optional fields is backward-compatible) in both `pyproject.toml` and `chatbet_base_models/__init__.__version__`.

## Testing

`pytest tests/test_message_template.py -k BetsMessagesPlannatechErrorTypes` → **12 passed** (6 fields × 2 cases). Backward-compatible: legacy dicts without these keys still deserialize.