### PR TITLE
feat(message-template): add account_frozen and non_combinable_selection bet-rejection templates [staging]

### DIFF
--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # Message Templates
 from .message_template import (

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -424,6 +424,11 @@ class BetsMessages(BaseModel):
     # stake*odds >= min) -> operator-configurable copy. Semantic field name
     # (winning, not stake) per SDD change `betcris-minimum-win-message`.
     minimum_potential_winning: Optional[MessageItem] = None
+    # iSolutions -32 errorTypes -> operator-configurable business-facing bet UX.
+    # `account_frozen` maps to `AccountFrozen`; `non_combinable_selection` maps
+    # to `NonCombinableSelection`. Companion to sportbook-services PRs #589/#626.
+    account_frozen: Optional[MessageItem] = None
+    non_combinable_selection: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.0"
+version = "1.0.1"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -625,6 +625,8 @@ class TestBetsMessagesPlannatechErrorTypes:
         "bet_limit_exceeded",
         "bet_amount_too_low",
         "minimum_potential_winning",
+        "account_frozen",
+        "non_combinable_selection",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)


### PR DESCRIPTION
Staging cherry-pick of #180 (already merged to develop).

Adds `account_frozen`, `market_unavailable` and `non_combinable_selection` bet-rejection fields to the `MessageTemplates` model so operators can edit them per company.

Must be deployed to staging **before** channel-services #811-staging and backoffice #689-staging (base-models installed by env-branch; `extra="forbid"` will 500 otherwise).

ClickUp: CU-86aj0z29w
