### PR TITLE
feat(message-template): add contact_support bet-rejection template [staging]

### DIFF
--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # Message Templates
 from .message_template import (

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -429,6 +429,12 @@ class BetsMessages(BaseModel):
     # to `NonCombinableSelection`. Companion to sportbook-services PRs #589/#626.
     account_frozen: Optional[MessageItem] = None
     non_combinable_selection: Optional[MessageItem] = None
+    # Plannatech errorTypes `ErrSecNoRight` / `ContactSupport` -> a dedicated
+    # operator-configurable "contact support" bet-reject message EACH, so an
+    # operator can tailor a distinct copy per case. Buttons are code-owned in
+    # bet-bot (Menu only, never Try-Again). Field names mirror the errorType.
+    err_sec_no_right: Optional[MessageItem] = None
+    contact_support: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.1"
+version = "1.0.2"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -627,6 +627,8 @@ class TestBetsMessagesPlannatechErrorTypes:
         "minimum_potential_winning",
         "account_frozen",
         "non_combinable_selection",
+        "err_sec_no_right",
+        "contact_support",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)


### PR DESCRIPTION
Staging counterpart of the base-models `err_sec_no_right` + `contact_support` fields.

⚠️ **Stacked** on `cherry/86aj0z29w-bet-rejection-templates-staging` (#181). **Retarget to `staging` once #181 merges.** Version `1.0.2`.
