### PR TITLE
feat(message-template): add insufficient_balance_prompt to BetsMessages

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -435,6 +435,15 @@ class BetsMessages(BaseModel):
     # bet-bot (Menu only, never Try-Again). Field names mirror the errorType.
     err_sec_no_right: Optional[MessageItem] = None
     contact_support: Optional[MessageItem] = None
+    # Proactive (pre-confirm) insufficient-balance message shown by the
+    # `_proactive_balance_check` helper in `confirm_bet`/`place_user_bet`.
+    # See SDD change `proactive-balance-validation` (bet-bot). Distinct from
+    # the reactive `without_funds` field: this one supports a `{balance}`
+    # placeholder. Operator override is sticky and NOT auto-regenerated;
+    # when unset, bet-bot falls back to a per-language default sourced from
+    # its own `bet_rejection_copy.py` table (no seeding here, same pattern
+    # as `account_frozen`/`market_unavailable`/etc.).
+    insufficient_balance_prompt: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -957,6 +957,56 @@ class TestBetsMessagesMinimumPotentialWinning:
         bets = BetsMessages.model_validate(legacy)
         assert bets.minimum_potential_winning is None
         assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
+
+
+class TestBetsMessagesInsufficientBalancePrompt:
+    """Validate `insufficient_balance_prompt`, added under BetsMessages for the
+    companion SDD change `proactive-balance-validation` (bet-bot).
+
+    Distinct from the reactive `without_funds` field: this one is shown by a
+    proactive pre-confirm balance check and supports a `{balance}` placeholder.
+    The field is `Optional[MessageItem] = None`; like `minimum_potential_winning`
+    it is NOT seeded by `from_minimal()` -- bet-bot supplies a per-language
+    fallback via its own `bet_rejection_copy.py` table when unset. Existing
+    DynamoDB items without the key must deserialize unchanged (no migration)."""
+
+    def test_insufficient_balance_prompt_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.insufficient_balance_prompt is None
+
+    def test_from_minimal_leaves_insufficient_balance_prompt_none(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.bets.insufficient_balance_prompt is None
+
+    def test_insufficient_balance_prompt_round_trip_and_string_coercion(self):
+        bets = BetsMessages.model_validate(
+            {"insufficient_balance_prompt": "Insufficient funds. Balance: {balance}"}
+        )
+        assert (
+            bets.insufficient_balance_prompt.text
+            == "Insufficient funds. Balance: {balance}"
+        )
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert (
+            dumped["insufficient_balance_prompt"]["text"]
+            == "Insufficient funds. Balance: {balance}"
+        )
+
+    def test_legacy_bets_dict_without_insufficient_balance_prompt_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must load
+        and leave `insufficient_balance_prompt` as `None` (no migration required).
+
+        Critical because BetsMessages uses ConfigDict(extra="forbid")."""
+        legacy = {
+            "select_sport": {"text": "Select sport"},
+            "bet_amount": {"text": "Enter amount"},
+            "bet_rejected": {"text": "Your bet was rejected. Please try again."},
+            "placed_bet": {"text": "Bet placed"},
+        }
+        bets = BetsMessages.model_validate(legacy)
+        assert bets.insufficient_balance_prompt is None
+        assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
         assert bets.select_sport.text == "Select sport"
 
     def test_minimum_potential_winning_round_trip_via_model_validate_and_dump(self):


### PR DESCRIPTION
## Qué

Agrega el campo `insufficient_balance_prompt` a `BetsMessages` en el modelo compartido de mensajes.

- `BetsMessages.insufficient_balance_prompt: Optional[MessageItem] = None`
- Soporta el placeholder `{balance}`.
- Default `None` (NO seedeado en `from_minimal()`), siguiendo el patrón de los mensajes hermanos de rechazo (`account_frozen`, `market_unavailable`, `minimum_potential_winning`). El texto por idioma (en/es/pt_br) lo provee `bet-bot` vía `bet_rejection_copy.py` cuando el campo está sin setear; el override del operador es sticky.

## Por qué

Da soporte a la validación proactiva de saldo ([ClickUp 86aj05e1d](https://app.clickup.com/t/86aj05e1d)): hoy el 50% de las apuestas se rechazan y el 90% de esos rechazos es por saldo insuficiente. El bot necesita un mensaje dedicado para avisar de forma proactiva antes de intentar la apuesta.

## Tests

`pytest`: 462/462 pass (incluye los tests nuevos de `insufficient_balance_prompt`).

## Secuencia de merge (IMPORTANTE)

Este PR es el **primero** de una cadena de 3 y debe mergearse ANTES que los otros dos (los modelos usan `extra="forbid"`):

1. **Este PR** (chatbet-base-models) → merge primero.
2. **bet-bot** `feat/proactive-balance-validation` → mergear + redeploy con el pin de base-models actualizado.
3. **chatbet-backoffice** `feat/message-template-placeholder-validation` → recién al final, bumpeando el pin del submodule.

Invertir el orden rompe el parseo de `CompanyConfig` per-tenant en bet-bot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional message template for proactive insufficient-balance prompts, with support for showing the current balance.
* **Bug Fixes**
  * Improved template handling so missing balance prompt data continues to load safely.
  * Preserved existing behavior for legacy message data while keeping other template fields intact.
* **Tests**
  * Added coverage for default values, string-to-template conversion, serialization, and backward-compatible deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->