### PR TITLE
Promote develop → staging (insufficient_balance_prompt + pending dev)

### DIFF
--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # Message Templates
 from .message_template import (

--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # Message Templates
 from .message_template import (

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -247,6 +247,14 @@ class ValidationMessages(BaseModel):
     error_otp: Optional[MessageItem] = None
     blocked_otp: Optional[MessageItem] = None
     blocked_user: Optional[MessageItem] = None
+    # BO-editable override for the WhatsApp detected-number login confirm
+    # screen. See SDD change `whatsapp-detected-number-login`. The prompt
+    # supports a `{phone}` placeholder (the detected/masked sender number) and
+    # carries two buttons with callbacks `use_detected_phone` (use this number)
+    # and `change_account_otp` (change number). When absent, bet-bot falls back
+    # to hardcoded localized defaults (account_state_defaults pattern), so empty
+    # configs are safe.
+    confirm_phone_number: Optional[MessageItem] = None
     # Plannatech `terms_not_accepted` (Result=-1219) signaling.
     # See SDD change `terms-not-accepted`.
     terms_not_accepted: Optional[MessageItem] = None
@@ -307,6 +315,11 @@ class ValidationMessages(BaseModel):
     def _error_otp_rules(cls, v):
         return require_callbacks(v, ["send_otp"])
 
+    @field_validator("confirm_phone_number")
+    @classmethod
+    def _confirm_phone_number_rules(cls, v):
+        return require_callbacks(v, ["use_detected_phone", "change_account_otp"])
+
     @model_validator(mode="after")
     def _require_callbacks(self):
         need = {"send_otp"}
@@ -321,6 +334,14 @@ class ValidationMessages(BaseModel):
             missing = need - got
             if missing:
                 raise ValueError(f"{field} missing callbacks: {sorted(missing)}")
+        if self.confirm_phone_number is not None:
+            need_confirm = {"use_detected_phone", "change_account_otp"}
+            got = extract(self.confirm_phone_number)
+            missing = need_confirm - got
+            if missing:
+                raise ValueError(
+                    f"confirm_phone_number missing callbacks: {sorted(missing)}"
+                )
         return self
 
 

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -1067,6 +1067,28 @@ class MessageTemplates(BaseModel):
                 blocked_user=MessageItem(
                     text="Sorry, I can't help you, you are blocked",
                 ),
+                confirm_phone_number=MessageItem(
+                    text=(
+                        "Detectamos que nos escribís desde {phone}.\n"
+                        "¿Querés ingresar con este número?"
+                    ),
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="✅ Usar este número",
+                                    callback_data="use_detected_phone",
+                                )
+                            ],
+                            [
+                                InlineKeyboardButton(
+                                    text="✏️ Cambiar número",
+                                    callback_data="change_account_otp",
+                                )
+                            ],
+                        ]
+                    ),
+                ),
                 password_required=MessageItem(
                     text="Para continuar, completá el formulario rápido 👇",
                 ),

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -424,6 +424,11 @@ class BetsMessages(BaseModel):
     # stake*odds >= min) -> operator-configurable copy. Semantic field name
     # (winning, not stake) per SDD change `betcris-minimum-win-message`.
     minimum_potential_winning: Optional[MessageItem] = None
+    # iSolutions -32 errorTypes -> operator-configurable business-facing bet UX.
+    # `account_frozen` maps to `AccountFrozen`; `non_combinable_selection` maps
+    # to `NonCombinableSelection`. Companion to sportbook-services PRs #589/#626.
+    account_frozen: Optional[MessageItem] = None
+    non_combinable_selection: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -429,6 +429,12 @@ class BetsMessages(BaseModel):
     # to `NonCombinableSelection`. Companion to sportbook-services PRs #589/#626.
     account_frozen: Optional[MessageItem] = None
     non_combinable_selection: Optional[MessageItem] = None
+    # Plannatech errorTypes `ErrSecNoRight` / `ContactSupport` -> a dedicated
+    # operator-configurable "contact support" bet-reject message EACH, so an
+    # operator can tailor a distinct copy per case. Buttons are code-owned in
+    # bet-bot (Menu only, never Try-Again). Field names mirror the errorType.
+    err_sec_no_right: Optional[MessageItem] = None
+    contact_support: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -435,6 +435,15 @@ class BetsMessages(BaseModel):
     # bet-bot (Menu only, never Try-Again). Field names mirror the errorType.
     err_sec_no_right: Optional[MessageItem] = None
     contact_support: Optional[MessageItem] = None
+    # Proactive (pre-confirm) insufficient-balance message shown by the
+    # `_proactive_balance_check` helper in `confirm_bet`/`place_user_bet`.
+    # See SDD change `proactive-balance-validation` (bet-bot). Distinct from
+    # the reactive `without_funds` field: this one supports a `{balance}`
+    # placeholder. Operator override is sticky and NOT auto-regenerated;
+    # when unset, bet-bot falls back to a per-language default sourced from
+    # its own `bet_rejection_copy.py` table (no seeding here, same pattern
+    # as `account_frozen`/`market_unavailable`/etc.).
+    insufficient_balance_prompt: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -350,6 +350,10 @@ class FeaturesConfig(BaseModel):
         default=False,
         description="Enable or disable live in this configuration",
     )
+    whatsapp_detected_login: Optional[bool] = Field(
+        default=False,
+        description="Enable WhatsApp detected-number login confirm screen (per-company rollout). When False, WhatsApp users keep the type-the-number flow.",
+    )
     fixture_range_days: Optional[int] = Field(
         default=7,
         ge=1,
@@ -435,6 +439,7 @@ class SiteConfig(BaseModel):
             hour_format=HourFormat.H24,
             skip_pre_auth_validation=False,
             live=False,
+            whatsapp_detected_login=False,
             fixture_range_days=7,
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.0"
+version = "1.0.1"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.1"
+version = "1.0.2"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -387,6 +387,26 @@ class TestValidationMessagesConfirmPhoneNumber:
         }
         assert cbs == {"use_detected_phone", "change_account_otp"}
 
+    def test_from_minimal_seeds_confirm_phone_number(self):
+        """`from_minimal()` auto-seeds a valid `confirm_phone_number` so NEW
+        companies get an editable WhatsApp detected-number login confirm
+        template out of the box (existing companies covered by the
+        channel-services migration)."""
+        templates = MessageTemplates.from_minimal()
+        item = templates.validation.confirm_phone_number
+        assert item is not None
+        # Prompt carries the {phone} placeholder the renderer substitutes.
+        assert "{phone}" in item.text
+        # Exactly two rows, one button each, with the required BARE callbacks
+        # (no `oi:`/`ai:` prefix).
+        rows = item.reply_markup.inline_keyboard
+        assert len(rows) == 2
+        assert all(len(row) == 1 for row in rows)
+        assert rows[0][0].callback_data == "use_detected_phone"
+        assert rows[1][0].callback_data == "change_account_otp"
+        # The whole container re-validates (field + model validators pass).
+        MessageTemplates.model_validate(templates.model_dump())
+
     def test_confirm_phone_number_unknown_key_rejected(self):
         """`extra=forbid` keeps protecting against typos near the new field."""
         with pytest.raises(ValidationError):

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -261,6 +261,140 @@ class TestValidationMessagesPasswordTemplates:
             )
 
 
+def _confirm_phone_item(text="¿Ingresar con este número?"):
+    """Helper: a valid `confirm_phone_number` MessageItem carrying both
+    required callbacks (`use_detected_phone` + `change_account_otp`)."""
+    return MessageItem(
+        text=text,
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text="✅ Usar este número",
+                        callback_data="use_detected_phone",
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        text="✏️ Cambiar número",
+                        callback_data="change_account_otp",
+                    )
+                ],
+            ]
+        ),
+    )
+
+
+class TestValidationMessagesConfirmPhoneNumber:
+    """Validate the `confirm_phone_number` template added under ValidationMessages.
+
+    See SDD change `whatsapp-detected-number-login`. BO-editable override for the
+    WhatsApp detected-number login confirm screen: a prompt (supporting a
+    `{phone}` placeholder) plus two buttons carrying callbacks
+    `use_detected_phone` and `change_account_otp`. The field is
+    `Optional[MessageItem] = None` so existing company configs that omit it keep
+    validating; bet-bot falls back to hardcoded localized defaults when absent."""
+
+    def test_confirm_phone_number_defaults_to_none(self):
+        validation = ValidationMessages()
+        assert validation.confirm_phone_number is None
+
+    def test_confirm_phone_number_omitted_from_dict_yields_none(self):
+        validation = ValidationMessages.model_validate(
+            {"member_validation": "Please validate"}
+        )
+        assert validation.confirm_phone_number is None
+        assert validation.member_validation.text == "Please validate"
+
+    def test_confirm_phone_number_with_both_callbacks_validates(self):
+        validation = ValidationMessages(confirm_phone_number=_confirm_phone_item())
+        assert validation.confirm_phone_number is not None
+        got = {
+            btn.callback_data
+            for row in validation.confirm_phone_number.reply_markup.inline_keyboard
+            for btn in row
+        }
+        assert got == {"use_detected_phone", "change_account_otp"}
+
+    def test_confirm_phone_number_missing_callbacks_raises(self):
+        """Provided but WITHOUT the required callbacks must raise."""
+        with pytest.raises(ValueError):
+            ValidationMessages(
+                confirm_phone_number=MessageItem(
+                    text="¿Ingresar con este número?",
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="✅ Usar este número",
+                                    callback_data="use_detected_phone",
+                                )
+                            ]
+                            # missing `change_account_otp`
+                        ]
+                    ),
+                )
+            )
+
+    def test_confirm_phone_number_without_keyboard_raises(self):
+        """A plain-text item (no inline keyboard at all) must raise."""
+        with pytest.raises(ValueError):
+            ValidationMessages(
+                confirm_phone_number=MessageItem(text="¿Ingresar con este número?")
+            )
+
+    def test_confirm_phone_number_round_trip_via_model_validate_and_dump(self):
+        data = {
+            "confirm_phone_number": {
+                "text": "Detectamos que escribís desde {phone}. ¿Ingresar?",
+                "reply_markup": {
+                    "inline_keyboard": [
+                        [
+                            {
+                                "text": "✅ Usar este número",
+                                "callback_data": "use_detected_phone",
+                            }
+                        ],
+                        [
+                            {
+                                "text": "✏️ Cambiar número",
+                                "callback_data": "change_account_otp",
+                            }
+                        ],
+                    ]
+                },
+            }
+        }
+        validation = ValidationMessages.model_validate(data)
+        assert "{phone}" in validation.confirm_phone_number.text
+
+        dumped = validation.model_dump(exclude_none=True)
+        assert "confirm_phone_number" in dumped
+        reloaded = ValidationMessages.model_validate(dumped)
+        assert reloaded.confirm_phone_number.text == validation.confirm_phone_number.text
+
+    def test_confirm_phone_number_serializes_in_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        templates.validation.confirm_phone_number = _confirm_phone_item()
+        item = templates.to_dynamodb_item()
+        assert "confirm_phone_number" in item["validation"]
+        cbs = {
+            btn["callback_data"]
+            for row in item["validation"]["confirm_phone_number"]["reply_markup"][
+                "inline_keyboard"
+            ]
+            for btn in row
+        }
+        assert cbs == {"use_detected_phone", "change_account_otp"}
+
+    def test_confirm_phone_number_unknown_key_rejected(self):
+        """`extra=forbid` keeps protecting against typos near the new field."""
+        with pytest.raises(ValidationError):
+            ValidationMessages.model_validate(
+                {"confirm_phone_numbr": {"text": "typo"}}
+            )
+
+
 class TestValidationMessagesTermsNotAccepted:
     """Validate the `terms_not_accepted` template added under ValidationMessages.
 

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -625,6 +625,8 @@ class TestBetsMessagesPlannatechErrorTypes:
         "bet_limit_exceeded",
         "bet_amount_too_low",
         "minimum_potential_winning",
+        "account_frozen",
+        "non_combinable_selection",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -627,6 +627,8 @@ class TestBetsMessagesPlannatechErrorTypes:
         "minimum_potential_winning",
         "account_frozen",
         "non_combinable_selection",
+        "err_sec_no_right",
+        "contact_support",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -957,6 +957,56 @@ class TestBetsMessagesMinimumPotentialWinning:
         bets = BetsMessages.model_validate(legacy)
         assert bets.minimum_potential_winning is None
         assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
+
+
+class TestBetsMessagesInsufficientBalancePrompt:
+    """Validate `insufficient_balance_prompt`, added under BetsMessages for the
+    companion SDD change `proactive-balance-validation` (bet-bot).
+
+    Distinct from the reactive `without_funds` field: this one is shown by a
+    proactive pre-confirm balance check and supports a `{balance}` placeholder.
+    The field is `Optional[MessageItem] = None`; like `minimum_potential_winning`
+    it is NOT seeded by `from_minimal()` -- bet-bot supplies a per-language
+    fallback via its own `bet_rejection_copy.py` table when unset. Existing
+    DynamoDB items without the key must deserialize unchanged (no migration)."""
+
+    def test_insufficient_balance_prompt_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.insufficient_balance_prompt is None
+
+    def test_from_minimal_leaves_insufficient_balance_prompt_none(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.bets.insufficient_balance_prompt is None
+
+    def test_insufficient_balance_prompt_round_trip_and_string_coercion(self):
+        bets = BetsMessages.model_validate(
+            {"insufficient_balance_prompt": "Insufficient funds. Balance: {balance}"}
+        )
+        assert (
+            bets.insufficient_balance_prompt.text
+            == "Insufficient funds. Balance: {balance}"
+        )
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert (
+            dumped["insufficient_balance_prompt"]["text"]
+            == "Insufficient funds. Balance: {balance}"
+        )
+
+    def test_legacy_bets_dict_without_insufficient_balance_prompt_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must load
+        and leave `insufficient_balance_prompt` as `None` (no migration required).
+
+        Critical because BetsMessages uses ConfigDict(extra="forbid")."""
+        legacy = {
+            "select_sport": {"text": "Select sport"},
+            "bet_amount": {"text": "Enter amount"},
+            "bet_rejected": {"text": "Your bet was rejected. Please try again."},
+            "placed_bet": {"text": "Bet placed"},
+        }
+        bets = BetsMessages.model_validate(legacy)
+        assert bets.insufficient_balance_prompt is None
+        assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
         assert bets.select_sport.text == "Select sport"
 
     def test_minimum_potential_winning_round_trip_via_model_validate_and_dump(self):

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -520,6 +520,44 @@ class TestFeaturesConfig:
                     fixture_range_days=invalid,
                 )
 
+    def test_features_config_default_whatsapp_detected_login(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+        )
+        assert features.whatsapp_detected_login is False
+
+    def test_features_config_whatsapp_detected_login_enabled(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+            whatsapp_detected_login=True,
+        )
+        assert features.whatsapp_detected_login is True
+
+    def test_features_config_whatsapp_detected_login_round_trip(self):
+        features = FeaturesConfig.model_validate(
+            {
+                "odd_type": OddType.DECIMAL,
+                "validation": ValidationMethod.EMAIL,
+                "combos": True,
+                "chatbet_version": ChatbetVersion.V2,
+                "multigames_response": True,
+                "see_in_combo": True,
+                "whatsapp_detected_login": True,
+            }
+        )
+        assert features.whatsapp_detected_login is True
+        assert features.model_dump()["whatsapp_detected_login"] is True
+
 
 class TestMeta:
     def test_create_meta_with_defaults(self):


### PR DESCRIPTION

## Promote develop → staging

Batch promote del delta develop→staging. Incluye, entre otros cambios, la feature de **validación proactiva de saldo** ([ClickUp 86aj05e1d](https://app.clickup.com/t/86aj05e1d)) repartida en 3 repos.

### Orden de merge/deploy a staging (OBLIGATORIO — extra="forbid")
1. **chatbet-base-models** (campo `insufficient_balance_prompt`)
2. **chatbet-channel-services / bet-bot** (lógica proactiva) — desplegar con el pin de base-models actualizado
3. **chatbet-backoffice** (validación de placeholders + campo en el editor) — al final

Invertir el orden puede romper el parseo de `CompanyConfig` per-tenant si el BO persiste el campo antes de que bet-bot lo entienda.

### Nota de este repo
Aporta el campo `BetsMessages.insufficient_balance_prompt`. **Es el paso 1 de la secuencia — debe llegar a staging (y desplegarse) antes que bet-bot y backoffice.**
