### PR TITLE
feat: add widget customization fields to WebConfig

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -207,6 +207,25 @@ class WebConfig(BaseModel):
         description="Per-company CORS allowlist for the embeddable web widget",
     )
 
+    # Widget customization (Backoffice Widget editor). Additive with defaults
+    # so existing configs remain valid under ``extra="forbid"``.
+    accent_color: str = Field(
+        default="#7C46E7",
+        pattern=r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$",
+        description="Primary accent color for the widget (hex, 3 or 6 digits)",
+    )
+    persona_name: str = Field(
+        default="ChatBet Concierge",
+        max_length=40,
+        description="Display name of the widget assistant persona",
+    )
+    logo_url: Optional[str] = None
+    welcome_text: str = Field(
+        default="Tell me what you need — how things work, your account, anything. I'll take it from here.",
+        max_length=500,
+        description="Welcome/intro message shown by the widget",
+    )
+
 
 class Integrations(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -346,6 +346,34 @@ class TestIntegrations:
         assert web.enabled is True
         assert web.allowed_origins == []
 
+    def test_web_config_widget_defaults_applied(self):
+        # A config with NO widget-customization fields parses and applies
+        # the additive defaults (backward-compatible).
+        web = WebConfig()
+        assert web.accent_color == "#7C46E7"
+        assert web.persona_name == "ChatBet Concierge"
+        assert web.logo_url is None
+        assert web.welcome_text == (
+            "Tell me what you need — how things work, your account, "
+            "anything. I'll take it from here."
+        )
+
+    def test_web_config_accent_color_accepts_valid_hex(self):
+        assert WebConfig(accent_color="#abc").accent_color == "#abc"
+        assert WebConfig(accent_color="#A1B2C3").accent_color == "#A1B2C3"
+
+    def test_web_config_invalid_hex_raises(self):
+        with pytest.raises(ValidationError):
+            WebConfig(accent_color="12xyz")
+
+    def test_web_config_persona_name_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            WebConfig(persona_name="x" * 41)
+
+    def test_web_config_welcome_text_too_long_raises(self):
+        with pytest.raises(ValidationError):
+            WebConfig(welcome_text="x" * 501)
+
     def test_web_config_forbids_extra(self):
         with pytest.raises(ValidationError):
             WebConfig(unknown_field="x")


### PR DESCRIPTION
## Summary

Adds 4 **additive** widget-customization fields to `WebConfig` (`chatbet_base_models/site_config_model.py`), powering the new Backoffice **Widget editor**. These let each company brand their embeddable web chat widget:

| Field | Type | Default | Validation |
|-------|------|---------|-----------|
| `accent_color` | `str` | `#7C46E7` | hex pattern (3 or 6 digits) |
| `persona_name` | `str` | `ChatBet Concierge` | `max_length=40` |
| `logo_url` | `Optional[str]` | `None` | — |
| `welcome_text` | `str` | `Tell me what you need …` | `max_length=500` |

## Backward compatibility

`WebConfig` keeps `extra="forbid"`. All new fields are additive with defaults, so **existing site configs (with no widget fields) continue to parse and simply receive the defaults**. No data migration required.

## Tests

`tests/test_site_config_model.py`:
- config with no widget fields parses and applies defaults
- valid hex (`#abc`, `#A1B2C3`) accepted
- invalid hex `"12xyz"` raises `ValidationError`
- `persona_name` > 40 chars raises
- `welcome_text` > 500 chars raises

Full file suite: **97 passed**.

## GATE

This is the cross-repo **GATE** — it must merge to `develop` **before** the consumers that depend on it:
- `chatbet-channel-services` (public `GET /web/{company}/config`)
- `chatbet-web-widget` (runtime fetch of branding)
- `chatbet-backoffice` (Widget editor read/write)

Each consumer bumps its base-models ref to pick these fields up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added widget customization options for web configs, including accent color, persona name, logo URL, and welcome text.
  * Existing configurations continue to work with sensible defaults for all new fields.

* **Bug Fixes**
  * Added validation to keep accent colors in a valid hex format.
  * Enforced length limits on persona names and welcome messages to prevent invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->