### PR TITLE
release: 2026-07-10 (fin Sprint 7)

### DIFF
--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # Message Templates
 from .message_template import (

--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # Message Templates
 from .message_template import (

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -324,6 +324,10 @@ class BetsMessages(BaseModel):
     market_unavailable: Optional[MessageItem] = None
     bet_limit_exceeded: Optional[MessageItem] = None
     bet_amount_too_low: Optional[MessageItem] = None
+    # Plannatech errorType `BetAmountTooLow` (min potential-winning rule:
+    # stake*odds >= min) -> operator-configurable copy. Semantic field name
+    # (winning, not stake) per SDD change `betcris-minimum-win-message`.
+    minimum_potential_winning: Optional[MessageItem] = None
 
     @field_validator("select_type_of_bet")
     @classmethod

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -247,6 +247,14 @@ class ValidationMessages(BaseModel):
     error_otp: Optional[MessageItem] = None
     blocked_otp: Optional[MessageItem] = None
     blocked_user: Optional[MessageItem] = None
+    # BO-editable override for the WhatsApp detected-number login confirm
+    # screen. See SDD change `whatsapp-detected-number-login`. The prompt
+    # supports a `{phone}` placeholder (the detected/masked sender number) and
+    # carries two buttons with callbacks `use_detected_phone` (use this number)
+    # and `change_account_otp` (change number). When absent, bet-bot falls back
+    # to hardcoded localized defaults (account_state_defaults pattern), so empty
+    # configs are safe.
+    confirm_phone_number: Optional[MessageItem] = None
     # Plannatech `terms_not_accepted` (Result=-1219) signaling.
     # See SDD change `terms-not-accepted`.
     terms_not_accepted: Optional[MessageItem] = None
@@ -307,6 +315,11 @@ class ValidationMessages(BaseModel):
     def _error_otp_rules(cls, v):
         return require_callbacks(v, ["send_otp"])
 
+    @field_validator("confirm_phone_number")
+    @classmethod
+    def _confirm_phone_number_rules(cls, v):
+        return require_callbacks(v, ["use_detected_phone", "change_account_otp"])
+
     @model_validator(mode="after")
     def _require_callbacks(self):
         need = {"send_otp"}
@@ -321,6 +334,14 @@ class ValidationMessages(BaseModel):
             missing = need - got
             if missing:
                 raise ValueError(f"{field} missing callbacks: {sorted(missing)}")
+        if self.confirm_phone_number is not None:
+            need_confirm = {"use_detected_phone", "change_account_otp"}
+            got = extract(self.confirm_phone_number)
+            missing = need_confirm - got
+            if missing:
+                raise ValueError(
+                    f"confirm_phone_number missing callbacks: {sorted(missing)}"
+                )
         return self
 
 

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -1067,6 +1067,28 @@ class MessageTemplates(BaseModel):
                 blocked_user=MessageItem(
                     text="Sorry, I can't help you, you are blocked",
                 ),
+                confirm_phone_number=MessageItem(
+                    text=(
+                        "Detectamos que nos escribís desde {phone}.\n"
+                        "¿Querés ingresar con este número?"
+                    ),
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="✅ Usar este número",
+                                    callback_data="use_detected_phone",
+                                )
+                            ],
+                            [
+                                InlineKeyboardButton(
+                                    text="✏️ Cambiar número",
+                                    callback_data="change_account_otp",
+                                )
+                            ],
+                        ]
+                    ),
+                ),
                 password_required=MessageItem(
                     text="Para continuar, completá el formulario rápido 👇",
                 ),

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -384,6 +384,13 @@ class BetsMessages(BaseModel):
     bet_rejected: Optional[MessageItem] = None
     bet_rejected_duplicate: Optional[MessageItem] = None
     select_type_of_bet: Optional[MessageItem] = None
+    # Dedicated template for the betslip "Add to a combo" follow-up bubble.
+    # See SDD change `add-to-combo-offer-dedicated-key`. `.text` is the bubble
+    # prompt; `reply_markup` carries a SINGLE button whose `.text` is the button
+    # label. The button's `callback_data` here is only a placeholder — the real
+    # callback is injected by the consuming app's code, so no callback validator
+    # is attached to this field.
+    add_to_combo_offer: Optional[MessageItem] = None
     closed_fixture: Optional[MessageItem] = None
     # Plannatech errorType -> operator-configurable business-facing bet UX.
     # See SDD change `plannatech-errortype-mapping`. InsufficientBalance reuses
@@ -1138,6 +1145,19 @@ class MessageTemplates(BaseModel):
                                 InlineKeyboardButton(
                                     text="Combo",
                                     callback_data="add_market_to_combo&{FIXTURE_ID}",
+                                ),
+                            ]
+                        ]
+                    ),
+                ),
+                add_to_combo_offer=MessageItem(
+                    text="Want to turn this into a combo? Add this pick as the first leg.",
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="➕ Add to a combo",
+                                    callback_data="add_to_combo",
                                 ),
                             ]
                         ]

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -424,6 +424,11 @@ class BetsMessages(BaseModel):
     # stake*odds >= min) -> operator-configurable copy. Semantic field name
     # (winning, not stake) per SDD change `betcris-minimum-win-message`.
     minimum_potential_winning: Optional[MessageItem] = None
+    # iSolutions -32 errorTypes -> operator-configurable business-facing bet UX.
+    # `account_frozen` maps to `AccountFrozen`; `non_combinable_selection` maps
+    # to `NonCombinableSelection`. Companion to sportbook-services PRs #589/#626.
+    account_frozen: Optional[MessageItem] = None
+    non_combinable_selection: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -404,29 +404,11 @@ class BetsMessages(BaseModel):
     # (winning, not stake) per SDD change `betcris-minimum-win-message`.
     minimum_potential_winning: Optional[MessageItem] = None
 
-    @field_validator("select_type_of_bet")
-    @classmethod
-    def _type_of_bet_rules(cls, v):
-        return require_callbacks(
-            v, ["bet_simple&{FIXTURE_ID}", "add_market_to_combo&{FIXTURE_ID}"]
-        )
-
     @classmethod
     def model_validate(cls, obj):
         if isinstance(obj, dict):
             obj = {k: MessageItem._coerce(v) for k, v in obj.items()}
         return super().model_validate(obj)
-
-    @model_validator(mode="after")
-    def _require_callbacks(self):
-        if self.select_type_of_bet is None:
-            return self
-        need = {"bet_simple&{FIXTURE_ID}", "add_market_to_combo&{FIXTURE_ID}"}
-        got = extract(self.select_type_of_bet)
-        missing = need - got
-        if missing:
-            raise ValueError(f"select_type_of_bet missing callbacks: {sorted(missing)}")
-        return self
 
 
 class CombosMessages(BaseModel):

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -429,6 +429,12 @@ class BetsMessages(BaseModel):
     # to `NonCombinableSelection`. Companion to sportbook-services PRs #589/#626.
     account_frozen: Optional[MessageItem] = None
     non_combinable_selection: Optional[MessageItem] = None
+    # Plannatech errorTypes `ErrSecNoRight` / `ContactSupport` -> a dedicated
+    # operator-configurable "contact support" bet-reject message EACH, so an
+    # operator can tailor a distinct copy per case. Buttons are code-owned in
+    # bet-bot (Menu only, never Try-Again). Field names mirror the errorType.
+    err_sec_no_right: Optional[MessageItem] = None
+    contact_support: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -435,6 +435,15 @@ class BetsMessages(BaseModel):
     # bet-bot (Menu only, never Try-Again). Field names mirror the errorType.
     err_sec_no_right: Optional[MessageItem] = None
     contact_support: Optional[MessageItem] = None
+    # Proactive (pre-confirm) insufficient-balance message shown by the
+    # `_proactive_balance_check` helper in `confirm_bet`/`place_user_bet`.
+    # See SDD change `proactive-balance-validation` (bet-bot). Distinct from
+    # the reactive `without_funds` field: this one supports a `{balance}`
+    # placeholder. Operator override is sticky and NOT auto-regenerated;
+    # when unset, bet-bot falls back to a per-language default sourced from
+    # its own `bet_rejection_copy.py` table (no seeding here, same pattern
+    # as `account_frozen`/`market_unavailable`/etc.).
+    insufficient_balance_prompt: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):

--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -244,7 +244,7 @@ def _reject_html(value: str, field: str) -> str:
 
 class PersonalityConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    bot_name: str = Field(default="ChatBet", min_length=2, max_length=20)
+    bot_name: str = Field(default="", max_length=20)
     formality_level: int = Field(default=2, ge=1, le=5)
     emoji_level: int = Field(default=2, ge=1, le=3)
     response_length: int = Field(default=1, ge=1, le=3)

--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -350,6 +350,10 @@ class FeaturesConfig(BaseModel):
         default=False,
         description="Enable or disable live in this configuration",
     )
+    whatsapp_detected_login: Optional[bool] = Field(
+        default=False,
+        description="Enable WhatsApp detected-number login confirm screen (per-company rollout). When False, WhatsApp users keep the type-the-number flow.",
+    )
     fixture_range_days: Optional[int] = Field(
         default=7,
         ge=1,
@@ -435,6 +439,7 @@ class SiteConfig(BaseModel):
             hour_format=HourFormat.H24,
             skip_pre_auth_validation=False,
             live=False,
+            whatsapp_detected_login=False,
             fixture_range_days=7,
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.0"
+version = "1.0.1"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.1"
+version = "1.0.2"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -389,7 +389,12 @@ class TestBetsMessagesPlannatechErrorTypes:
     InsufficientBalance reuses the existing `without_funds` field; these cover
     the remaining business errorTypes. Each is `Optional[MessageItem] = None`."""
 
-    NEW_FIELDS = ["market_unavailable", "bet_limit_exceeded", "bet_amount_too_low"]
+    NEW_FIELDS = [
+        "market_unavailable",
+        "bet_limit_exceeded",
+        "bet_amount_too_low",
+        "minimum_potential_winning",
+    ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)
     def test_field_defaults_to_none(self, field):
@@ -597,6 +602,65 @@ class TestBetsMessagesBetRejectedDuplicate:
             bet_rejected_duplicate=MessageItem(text="You hit the duplicate limit"),
         )
         assert bets.bet_rejected_duplicate.text == "You hit the duplicate limit"
+
+
+class TestBetsMessagesMinimumPotentialWinning:
+    """Validate the `minimum_potential_winning` template added under BetsMessages.
+
+    Operators can configure a per-company message shown when Plannatech rejects a
+    bet with errorType `BetAmountTooLow` (the min potential-winning rule). The
+    field is `Optional[MessageItem] = None`; like `bet_amount_too_low` it is NOT
+    seeded by `from_minimal()` (the renderer supplies an EN fallback). Existing
+    DynamoDB items without the key must deserialize unchanged (no migration)."""
+
+    def test_minimum_potential_winning_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.minimum_potential_winning is None
+
+    def test_from_minimal_leaves_minimum_potential_winning_none(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.bets.minimum_potential_winning is None
+
+    def test_legacy_bets_dict_without_minimum_potential_winning_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must load
+        and leave `minimum_potential_winning` as `None` (no migration required).
+
+        Critical because BetsMessages uses ConfigDict(extra="forbid")."""
+        legacy = {
+            "select_sport": {"text": "Select sport"},
+            "bet_amount": {"text": "Enter amount"},
+            "bet_rejected": {"text": "Your bet was rejected. Please try again."},
+            "placed_bet": {"text": "Bet placed"},
+        }
+        bets = BetsMessages.model_validate(legacy)
+        assert bets.minimum_potential_winning is None
+        assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
+        assert bets.select_sport.text == "Select sport"
+
+    def test_minimum_potential_winning_round_trip_via_model_validate_and_dump(self):
+        """New dict with the field round-trips through model_validate → model_dump
+        under `extra="forbid"`."""
+        configured_text = (
+            "The potential winnings of your bet are below the allowed minimum. "
+            "Increase your stake or pick higher odds to continue."
+        )
+        data = {"minimum_potential_winning": {"text": configured_text}}
+        bets = BetsMessages.model_validate(data)
+        assert bets.minimum_potential_winning is not None
+        assert bets.minimum_potential_winning.text == configured_text
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert "minimum_potential_winning" in dumped
+        assert dumped["minimum_potential_winning"]["text"] == configured_text
+
+        reloaded = BetsMessages.model_validate(dumped)
+        assert reloaded.minimum_potential_winning.text == configured_text
+
+    def test_minimum_potential_winning_override_via_constructor(self):
+        bets = BetsMessages(
+            minimum_potential_winning=MessageItem(text="Potential win too low"),
+        )
+        assert bets.minimum_potential_winning.text == "Potential win too low"
 
 
 class TestCombosMessages:

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -387,6 +387,26 @@ class TestValidationMessagesConfirmPhoneNumber:
         }
         assert cbs == {"use_detected_phone", "change_account_otp"}
 
+    def test_from_minimal_seeds_confirm_phone_number(self):
+        """`from_minimal()` auto-seeds a valid `confirm_phone_number` so NEW
+        companies get an editable WhatsApp detected-number login confirm
+        template out of the box (existing companies covered by the
+        channel-services migration)."""
+        templates = MessageTemplates.from_minimal()
+        item = templates.validation.confirm_phone_number
+        assert item is not None
+        # Prompt carries the {phone} placeholder the renderer substitutes.
+        assert "{phone}" in item.text
+        # Exactly two rows, one button each, with the required BARE callbacks
+        # (no `oi:`/`ai:` prefix).
+        rows = item.reply_markup.inline_keyboard
+        assert len(rows) == 2
+        assert all(len(row) == 1 for row in rows)
+        assert rows[0][0].callback_data == "use_detected_phone"
+        assert rows[1][0].callback_data == "change_account_otp"
+        # The whole container re-validates (field + model validators pass).
+        MessageTemplates.model_validate(templates.model_dump())
+
     def test_confirm_phone_number_unknown_key_rejected(self):
         """`extra=forbid` keeps protecting against typos near the new field."""
         with pytest.raises(ValidationError):

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -563,6 +563,63 @@ class TestBetsMessages:
         assert bets.select_sport.text == "Select sport"
         assert bets.bet_amount.text == "Enter amount"
 
+    def test_add_to_combo_offer_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.add_to_combo_offer is None
+
+    def test_add_to_combo_offer_accepts_message_item(self):
+        bets = BetsMessages(
+            add_to_combo_offer=MessageItem(
+                text="Add this pick as the first leg.",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="➕ Add to a combo",
+                                callback_data="add_to_combo",
+                            ),
+                        ]
+                    ]
+                ),
+            )
+        )
+        assert bets.add_to_combo_offer.text == "Add this pick as the first leg."
+        button = bets.add_to_combo_offer.reply_markup.inline_keyboard[0][0]
+        assert button.text == "➕ Add to a combo"
+        # callback_data is a code-injected placeholder; no validator enforced.
+        assert button.callback_data == "add_to_combo"
+
+    def test_add_to_combo_offer_from_minimal(self):
+        templates = MessageTemplates.from_minimal()
+        offer = templates.bets.add_to_combo_offer
+        assert offer is not None
+        assert offer.text == (
+            "Want to turn this into a combo? Add this pick as the first leg."
+        )
+        button = offer.reply_markup.inline_keyboard[0][0]
+        assert button.text == "➕ Add to a combo"
+        assert button.callback_data == "add_to_combo"
+
+    def test_add_to_combo_offer_round_trips_through_serialization(self):
+        templates = MessageTemplates.from_minimal()
+        item = templates.to_dynamodb_item()
+        assert "add_to_combo_offer" in item["bets"]
+        offer = item["bets"]["add_to_combo_offer"]
+        assert offer["text"] == (
+            "Want to turn this into a combo? Add this pick as the first leg."
+        )
+        button = offer["reply_markup"]["inline_keyboard"][0][0]
+        assert button["text"] == "➕ Add to a combo"
+        assert button["callback_data"] == "add_to_combo"
+
+        # Deserialize back and confirm the field survives the round-trip.
+        restored = BetsMessages.model_validate(item["bets"])
+        assert restored.add_to_combo_offer is not None
+        assert (
+            restored.add_to_combo_offer.reply_markup.inline_keyboard[0][0].text
+            == "➕ Add to a combo"
+        )
+
 
 class TestBetsMessagesLiveDisclaimer:
     """Validate the `live_disclaimer` template added under BetsMessages.

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -261,6 +261,140 @@ class TestValidationMessagesPasswordTemplates:
             )
 
 
+def _confirm_phone_item(text="¿Ingresar con este número?"):
+    """Helper: a valid `confirm_phone_number` MessageItem carrying both
+    required callbacks (`use_detected_phone` + `change_account_otp`)."""
+    return MessageItem(
+        text=text,
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(
+                        text="✅ Usar este número",
+                        callback_data="use_detected_phone",
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        text="✏️ Cambiar número",
+                        callback_data="change_account_otp",
+                    )
+                ],
+            ]
+        ),
+    )
+
+
+class TestValidationMessagesConfirmPhoneNumber:
+    """Validate the `confirm_phone_number` template added under ValidationMessages.
+
+    See SDD change `whatsapp-detected-number-login`. BO-editable override for the
+    WhatsApp detected-number login confirm screen: a prompt (supporting a
+    `{phone}` placeholder) plus two buttons carrying callbacks
+    `use_detected_phone` and `change_account_otp`. The field is
+    `Optional[MessageItem] = None` so existing company configs that omit it keep
+    validating; bet-bot falls back to hardcoded localized defaults when absent."""
+
+    def test_confirm_phone_number_defaults_to_none(self):
+        validation = ValidationMessages()
+        assert validation.confirm_phone_number is None
+
+    def test_confirm_phone_number_omitted_from_dict_yields_none(self):
+        validation = ValidationMessages.model_validate(
+            {"member_validation": "Please validate"}
+        )
+        assert validation.confirm_phone_number is None
+        assert validation.member_validation.text == "Please validate"
+
+    def test_confirm_phone_number_with_both_callbacks_validates(self):
+        validation = ValidationMessages(confirm_phone_number=_confirm_phone_item())
+        assert validation.confirm_phone_number is not None
+        got = {
+            btn.callback_data
+            for row in validation.confirm_phone_number.reply_markup.inline_keyboard
+            for btn in row
+        }
+        assert got == {"use_detected_phone", "change_account_otp"}
+
+    def test_confirm_phone_number_missing_callbacks_raises(self):
+        """Provided but WITHOUT the required callbacks must raise."""
+        with pytest.raises(ValueError):
+            ValidationMessages(
+                confirm_phone_number=MessageItem(
+                    text="¿Ingresar con este número?",
+                    reply_markup=InlineKeyboardMarkup(
+                        inline_keyboard=[
+                            [
+                                InlineKeyboardButton(
+                                    text="✅ Usar este número",
+                                    callback_data="use_detected_phone",
+                                )
+                            ]
+                            # missing `change_account_otp`
+                        ]
+                    ),
+                )
+            )
+
+    def test_confirm_phone_number_without_keyboard_raises(self):
+        """A plain-text item (no inline keyboard at all) must raise."""
+        with pytest.raises(ValueError):
+            ValidationMessages(
+                confirm_phone_number=MessageItem(text="¿Ingresar con este número?")
+            )
+
+    def test_confirm_phone_number_round_trip_via_model_validate_and_dump(self):
+        data = {
+            "confirm_phone_number": {
+                "text": "Detectamos que escribís desde {phone}. ¿Ingresar?",
+                "reply_markup": {
+                    "inline_keyboard": [
+                        [
+                            {
+                                "text": "✅ Usar este número",
+                                "callback_data": "use_detected_phone",
+                            }
+                        ],
+                        [
+                            {
+                                "text": "✏️ Cambiar número",
+                                "callback_data": "change_account_otp",
+                            }
+                        ],
+                    ]
+                },
+            }
+        }
+        validation = ValidationMessages.model_validate(data)
+        assert "{phone}" in validation.confirm_phone_number.text
+
+        dumped = validation.model_dump(exclude_none=True)
+        assert "confirm_phone_number" in dumped
+        reloaded = ValidationMessages.model_validate(dumped)
+        assert reloaded.confirm_phone_number.text == validation.confirm_phone_number.text
+
+    def test_confirm_phone_number_serializes_in_dynamodb_item(self):
+        templates = MessageTemplates.from_minimal()
+        templates.validation.confirm_phone_number = _confirm_phone_item()
+        item = templates.to_dynamodb_item()
+        assert "confirm_phone_number" in item["validation"]
+        cbs = {
+            btn["callback_data"]
+            for row in item["validation"]["confirm_phone_number"]["reply_markup"][
+                "inline_keyboard"
+            ]
+            for btn in row
+        }
+        assert cbs == {"use_detected_phone", "change_account_otp"}
+
+    def test_confirm_phone_number_unknown_key_rejected(self):
+        """`extra=forbid` keeps protecting against typos near the new field."""
+        with pytest.raises(ValidationError):
+            ValidationMessages.model_validate(
+                {"confirm_phone_numbr": {"text": "typo"}}
+            )
+
+
 class TestValidationMessagesTermsNotAccepted:
     """Validate the `terms_not_accepted` template added under ValidationMessages.
 

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -567,6 +567,36 @@ class TestBetsMessages:
         bets = BetsMessages()
         assert bets.add_to_combo_offer is None
 
+    def test_select_type_of_bet_accepts_item_without_required_callbacks(self):
+        # The select_type_of_bet screen is unreachable dead code (rerouted by
+        # CU-86aj6gpa1) and no runtime reads its callbacks. Operators must be
+        # free to delete/rename its buttons from the Backoffice, so the field
+        # no longer requires the bet_simple/add_market_to_combo callbacks.
+        bets = BetsMessages(
+            select_type_of_bet=MessageItem(
+                text="Pick a bet type",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[
+                        [
+                            InlineKeyboardButton(
+                                text="Only one button now",
+                                callback_data="some_other_callback",
+                            ),
+                        ]
+                    ]
+                ),
+            )
+        )
+        button = bets.select_type_of_bet.reply_markup.inline_keyboard[0][0]
+        assert button.callback_data == "some_other_callback"
+
+    def test_select_type_of_bet_accepts_item_without_buttons(self):
+        # Operator may strip the keyboard entirely; this must not raise.
+        bets = BetsMessages(
+            select_type_of_bet=MessageItem(text="Pick a bet type"),
+        )
+        assert bets.select_type_of_bet.text == "Pick a bet type"
+
     def test_add_to_combo_offer_accepts_message_item(self):
         bets = BetsMessages(
             add_to_combo_offer=MessageItem(

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -625,6 +625,8 @@ class TestBetsMessagesPlannatechErrorTypes:
         "bet_limit_exceeded",
         "bet_amount_too_low",
         "minimum_potential_winning",
+        "account_frozen",
+        "non_combinable_selection",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -627,6 +627,8 @@ class TestBetsMessagesPlannatechErrorTypes:
         "minimum_potential_winning",
         "account_frozen",
         "non_combinable_selection",
+        "err_sec_no_right",
+        "contact_support",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -957,6 +957,56 @@ class TestBetsMessagesMinimumPotentialWinning:
         bets = BetsMessages.model_validate(legacy)
         assert bets.minimum_potential_winning is None
         assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
+
+
+class TestBetsMessagesInsufficientBalancePrompt:
+    """Validate `insufficient_balance_prompt`, added under BetsMessages for the
+    companion SDD change `proactive-balance-validation` (bet-bot).
+
+    Distinct from the reactive `without_funds` field: this one is shown by a
+    proactive pre-confirm balance check and supports a `{balance}` placeholder.
+    The field is `Optional[MessageItem] = None`; like `minimum_potential_winning`
+    it is NOT seeded by `from_minimal()` -- bet-bot supplies a per-language
+    fallback via its own `bet_rejection_copy.py` table when unset. Existing
+    DynamoDB items without the key must deserialize unchanged (no migration)."""
+
+    def test_insufficient_balance_prompt_defaults_to_none(self):
+        bets = BetsMessages()
+        assert bets.insufficient_balance_prompt is None
+
+    def test_from_minimal_leaves_insufficient_balance_prompt_none(self):
+        templates = MessageTemplates.from_minimal()
+        assert templates.bets.insufficient_balance_prompt is None
+
+    def test_insufficient_balance_prompt_round_trip_and_string_coercion(self):
+        bets = BetsMessages.model_validate(
+            {"insufficient_balance_prompt": "Insufficient funds. Balance: {balance}"}
+        )
+        assert (
+            bets.insufficient_balance_prompt.text
+            == "Insufficient funds. Balance: {balance}"
+        )
+
+        dumped = bets.model_dump(exclude_none=True)
+        assert (
+            dumped["insufficient_balance_prompt"]["text"]
+            == "Insufficient funds. Balance: {balance}"
+        )
+
+    def test_legacy_bets_dict_without_insufficient_balance_prompt_deserializes(self):
+        """Backwards-compat: a DDB-shaped dict that predates this field must load
+        and leave `insufficient_balance_prompt` as `None` (no migration required).
+
+        Critical because BetsMessages uses ConfigDict(extra="forbid")."""
+        legacy = {
+            "select_sport": {"text": "Select sport"},
+            "bet_amount": {"text": "Enter amount"},
+            "bet_rejected": {"text": "Your bet was rejected. Please try again."},
+            "placed_bet": {"text": "Bet placed"},
+        }
+        bets = BetsMessages.model_validate(legacy)
+        assert bets.insufficient_balance_prompt is None
+        assert bets.bet_rejected.text == "Your bet was rejected. Please try again."
         assert bets.select_sport.text == "Select sport"
 
     def test_minimum_potential_winning_round_trip_via_model_validate_and_dump(self):

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -520,6 +520,44 @@ class TestFeaturesConfig:
                     fixture_range_days=invalid,
                 )
 
+    def test_features_config_default_whatsapp_detected_login(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+        )
+        assert features.whatsapp_detected_login is False
+
+    def test_features_config_whatsapp_detected_login_enabled(self):
+        features = FeaturesConfig(
+            odd_type=OddType.DECIMAL,
+            validation=ValidationMethod.EMAIL,
+            combos=True,
+            chatbet_version=ChatbetVersion.V2,
+            multigames_response=True,
+            see_in_combo=True,
+            whatsapp_detected_login=True,
+        )
+        assert features.whatsapp_detected_login is True
+
+    def test_features_config_whatsapp_detected_login_round_trip(self):
+        features = FeaturesConfig.model_validate(
+            {
+                "odd_type": OddType.DECIMAL,
+                "validation": ValidationMethod.EMAIL,
+                "combos": True,
+                "chatbet_version": ChatbetVersion.V2,
+                "multigames_response": True,
+                "see_in_combo": True,
+                "whatsapp_detected_login": True,
+            }
+        )
+        assert features.whatsapp_detected_login is True
+        assert features.model_dump()["whatsapp_detected_login"] is True
+
 
 class TestMeta:
     def test_create_meta_with_defaults(self):

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -29,6 +29,7 @@ from chatbet_base_models.site_config_model import (
     AuthConfig,
     SiteConfig,
     SiteConfigDB,
+    PersonalityConfig,
 )
 
 
@@ -366,6 +367,28 @@ class TestIdentity:
     def test_invalid_url_raises_error(self):
         with pytest.raises(ValueError):
             Identity(site_name="ChatBet", company_id="chatbet123", site_url="not-a-url")
+
+
+class TestPersonalityConfig:
+    def test_default_bot_name_is_empty(self):
+        personality = PersonalityConfig()
+        assert personality.bot_name == ""
+
+    def test_accepts_empty_bot_name(self):
+        personality = PersonalityConfig(bot_name="")
+        assert personality.bot_name == ""
+
+    def test_accepts_single_char_bot_name(self):
+        personality = PersonalityConfig(bot_name="X")
+        assert personality.bot_name == "X"
+
+    def test_rejects_bot_name_over_max_length(self):
+        with pytest.raises(ValidationError):
+            PersonalityConfig(bot_name="x" * 21)
+
+    def test_rejects_html_in_bot_name(self):
+        with pytest.raises(ValueError):
+            PersonalityConfig(bot_name="<script>alert(1)</script>")
 
 
 class TestLocaleConfig:


### PR DESCRIPTION
## Release semanal staging→main

Forward payload (todo validado):
- Version bump **1.0.0 → 1.0.2**
- `bot_name` relajado a default `"""
- **5 nuevos campos de BetsMessages**: `account_frozen`, `non_combinable_selection`, `err_sec_no_right`, `contact_support`, `insufficient_balance_prompt` + sus tests

~100 inserciones / 3 eliminaciones en 6 archivos.

## IMPORTANTE — nota de merge
`merge-tree` reporta **UN** conflicto en `chatbet_base_models/message_template.py`. Es un artefacto fantasma de cherry-pick. Resolver tomando el lado **RELEASE (staging)**: el `message_template.py` de staging es un superset estricto del de main. **NO perder los 5 campos nuevos de staging.**

## Dependencia de deploy
base-models debe hacer **merge + publish ANTES** de los deploys de prod de `chatbet-channel-services` y `chatbet-backoffice` (lib de modelos compartida, `extra=forbid` → 500s en caso contrario).