### PR TITLE
feat(labels): add balance_notification message template label

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -714,6 +714,7 @@ class LabelMessages(BaseModel):
     more_options_label: Optional[MessageItem] = None
     account_locked_text: Optional[MessageItem] = None
     invalid_otp_text: Optional[MessageItem] = None
+    balance_notification: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -1488,6 +1489,9 @@ class MessageTemplates(BaseModel):
                 more_options_label=MessageItem(text="More options"),
                 account_locked_text=MessageItem(text="Account locked"),
                 invalid_otp_text=MessageItem(text="Invalid OTP"),
+                balance_notification=MessageItem(
+                    text="Your available balance is {balance}"
+                ),
             ),
             end=EndMessages(
                 end_conversation=MessageItem(text="Bye!"),


### PR DESCRIPTION
## Qué
Agrega el label `balance_notification` (`Optional[MessageItem] = None`) a `LabelMessages`, más su default en `from_minimal()` ("Your available balance is {balance}").

## Por qué
Habilita el mensaje **editable por operador** que muestra el saldo del usuario al loguearse — ClickUp [86aj7tnh1](https://app.clickup.com/t/86aj7tnh1).

## Notas
- Campo aditivo y opcional → **backward-compatible**, no rompe configs ya persistidas.
- **Este PR debe mergearse PRIMERO** (base-models se instala pip-by-branch en el build; con `extra=forbid`, el skew de versión tira 500s).
- Tests: 220 pass.

Parte de un cambio cross-repo: base-models → channel-services → backoffice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default message template for notifying users of their available balance.
  * Balance notifications can now be customized or omitted when configuring message templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->