### PR TITLE
feat(labels): add balance_notification message template label [staging]

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -714,6 +714,7 @@ class LabelMessages(BaseModel):
     more_options_label: Optional[MessageItem] = None
     account_locked_text: Optional[MessageItem] = None
     invalid_otp_text: Optional[MessageItem] = None
+    balance_notification: Optional[MessageItem] = None
 
     @classmethod
     def model_validate(cls, obj):
@@ -1488,6 +1489,9 @@ class MessageTemplates(BaseModel):
                 more_options_label=MessageItem(text="More options"),
                 account_locked_text=MessageItem(text="Account locked"),
                 invalid_otp_text=MessageItem(text="Invalid OTP"),
+                balance_notification=MessageItem(
+                    text="Your available balance is {balance}"
+                ),
             ),
             end=EndMessages(
                 end_conversation=MessageItem(text="Bye!"),


### PR DESCRIPTION
Cherry-pick a staging de [#192](https://github.com/AIChatBet/chatbet-base-models/pull/192) (ya en develop).

Agrega el label `balance_notification` a `LabelMessages` + default en `from_minimal`. Aditivo/opcional → backward-compatible.

⚠️ **Mergear PRIMERO** (base-models se instala pip-by-branch; `extra=forbid` → skew = 500s). Luego channel-services + backoffice, y correr `migrate_balance_notification.py` en staging después.

ClickUp: [86aj7tnh1](https://app.clickup.com/t/86aj7tnh1)