### PR TITLE
feat(templates): add validation.contact_support account-state message (86ajbry87)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -234,6 +234,15 @@ DEFAULT_ACCOUNT_STATE: Dict[str, Dict[str, str]] = {
         "en": "Your account was blocked at your own request.",
         "pt-br": "Sua conta foi bloqueada a seu próprio pedido.",
     },
+    # Plannatech ContactSupport / ErrSecNoRight (verbatim passthrough) surfaced
+    # in the LOGIN/OTP flow. Distinct from the bet-flow `bets.contact_support`
+    # copy (which reads "we couldn't process this BET") — at login there is no
+    # bet yet, so the copy is account-oriented.
+    "contact_support": {
+        "es": "Hay un inconveniente con tu cuenta. Por favor, contactá a atención al cliente.",
+        "en": "There's an issue with your account. Please contact customer support.",
+        "pt-br": "Há um problema com a sua conta. Por favor, entre em contato com o atendimento ao cliente.",
+    },
 }
 
 
@@ -276,6 +285,11 @@ class ValidationMessages(BaseModel):
     unauthorized_user: Optional[MessageItem] = None
     user_not_found: Optional[MessageItem] = None
     account_blocked: Optional[MessageItem] = None
+    # Plannatech ContactSupport (-9022) / ErrSecNoRight account-state outcome in
+    # the login/OTP flow. Both errorTypes share this one operator-editable field.
+    # See ClickUp 86ajbry87. Absent -> hardcoded localized fallback
+    # (account_state_defaults["contact_support"]) so empty configs are safe.
+    contact_support: Optional[MessageItem] = None
     # Localized defaults for the account-state errorTypes above, mirroring the
     # `ErrorMessages.general_errors` rationale: auto-fills on load (model_validate /
     # constructor) even when the Dynamo item omits it, so consumers always have a

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -499,6 +499,7 @@ class TestValidationMessagesPlannatechErrorTypes:
         "unauthorized_user",
         "user_not_found",
         "account_blocked",
+        "contact_support",
     ]
 
     @pytest.mark.parametrize("field", NEW_FIELDS)
@@ -559,6 +560,7 @@ class TestValidationMessagesAccountStateDefaults:
         "betting_time_expired",
         "session_expired",
         "account_blocked_by_request",
+        "contact_support",
     ]
     LANGS = {"es", "en", "pt-br"}
 


### PR DESCRIPTION
## What

Adds an operator-editable, localized (es / en / pt-br) `contact_support` field to `ValidationMessages` and to `DEFAULT_ACCOUNT_STATE`.

This is account-oriented copy — a genuine per-account block instructing the user to contact customer support — and is intentionally **distinct** from the bet-flow `bets.contact_support` message. It is consumed by channel-services to close the Plannatech **ContactSupport (-9022) / ErrSecNoRight** login-flow gap.

## Notes

- Purely **additive** and `Optional`, so it is safe under `extra="forbid"`.
- 224 tests pass.
- **Merge order:** this PR MUST merge (and the package be installed per env) **before** the companion channel-services PR.

## Ticket

https://app.clickup.com/t/86ajbry87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable, localized contact-support messaging for account-related login and one-time-password validation outcomes.
  * Account-state defaults now include dedicated contact-support text separate from bet-flow messaging.

* **Bug Fixes**
  * Improved support for displaying the appropriate contact-support message when account access is restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->