### PR TITLE
feat: company-level enabled kill switch on SiteConfig

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -497,6 +497,17 @@ class AuthConfig(BaseModel):
 class SiteConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Company-level kill switch. When False, channel-services rejects "
+            "ALL inbound (Telegram + WhatsApp) for this operator BEFORE "
+            "building the orchestrator or calling the LLM. Used to "
+            "decommission a client without deleting its config. Defaults True "
+            "so existing operators stay live. For a WhatsApp-only switch use "
+            "integrations.whatsapp.enabled instead."
+        ),
+    )
     identity: Identity
     locale: LocaleConfig = Field(
         default_factory=lambda: LocaleConfig(

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -727,6 +727,30 @@ class TestSiteConfig:
         )
         assert config.session.inactivity_threshold_minutes == 60
 
+    def test_site_config_enabled_defaults_true(self):
+        """Company-level kill switch defaults to True so existing operators
+        (whose stored config predates the field) stay live."""
+        config = SiteConfig(
+            identity=Identity(
+                site_name="Test Site",
+                company_id="test123",
+                site_url="https://test.example.com",
+            )
+        )
+        assert config.enabled is True
+
+    def test_site_config_enabled_can_be_disabled(self):
+        """A decommissioned operator sets enabled=False to reject all inbound."""
+        config = SiteConfig(
+            identity=Identity(
+                site_name="Test Site",
+                company_id="test123",
+                site_url="https://test.example.com",
+            ),
+            enabled=False,
+        )
+        assert config.enabled is False
+
 
 class TestSiteConfigDB:
     def test_create_site_config_db(self):


### PR DESCRIPTION
## Qué

Agrega `SiteConfig.enabled: bool = True` — un kill switch a nivel operador que permite dar de baja un cliente en TODOS los canales sin borrar su config.

## Por qué

Cuando se deshabilita un operador (ej: betvip) se revoca el token del canal, pero eso solo rompe la SALIDA. Meta sigue entregando webhooks de entrada (la suscripción vive a nivel app, independiente del token), así que el cliente decomisionado sigue llegando al LLM, devolviendo `intent='error'` y disparando alertas en Slack/SNS + quemando plata en LLM.

## Notas

- Default `True` → los operadores actuales siguen vivos.
- **Sin migración**: `extra="forbid"` solo rechaza campos DESCONOCIDOS, no campos-que-faltan-con-default. Los configs viejos en DDB validan solos.
- Para un switch solo-WhatsApp existe `integrations.whatsapp.enabled`.
- ⚠️ **MERGE ORDER: este PR va PRIMERO.** El PR companion de channel-services usa `site_config.enabled` y su CI instala base-models por branch.

## Tests

+2 tests (default True, can disable). Suite completa 104/104 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a company-level enable/disable setting for inbound Telegram and WhatsApp requests.
  * Requests are rejected when the site is disabled, before further processing begins.
  * The setting defaults to enabled for existing configurations.

* **Tests**
  * Added coverage for the default enabled state and explicit disabling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->