### PR TITLE
feat: company-level enabled kill switch on SiteConfig (staging)

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -497,6 +497,17 @@ class AuthConfig(BaseModel):
 class SiteConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Company-level kill switch. When False, channel-services rejects "
+            "ALL inbound (Telegram + WhatsApp) for this operator BEFORE "
+            "building the orchestrator or calling the LLM. Used to "
+            "decommission a client without deleting its config. Defaults True "
+            "so existing operators stay live. For a WhatsApp-only switch use "
+            "integrations.whatsapp.enabled instead."
+        ),
+    )
     identity: Identity
     locale: LocaleConfig = Field(
         default_factory=lambda: LocaleConfig(

--- a/tests/test_site_config_model.py
+++ b/tests/test_site_config_model.py
@@ -727,6 +727,30 @@ class TestSiteConfig:
         )
         assert config.session.inactivity_threshold_minutes == 60
 
+    def test_site_config_enabled_defaults_true(self):
+        """Company-level kill switch defaults to True so existing operators
+        (whose stored config predates the field) stay live."""
+        config = SiteConfig(
+            identity=Identity(
+                site_name="Test Site",
+                company_id="test123",
+                site_url="https://test.example.com",
+            )
+        )
+        assert config.enabled is True
+
+    def test_site_config_enabled_can_be_disabled(self):
+        """A decommissioned operator sets enabled=False to reject all inbound."""
+        config = SiteConfig(
+            identity=Identity(
+                site_name="Test Site",
+                company_id="test123",
+                site_url="https://test.example.com",
+            ),
+            enabled=False,
+        )
+        assert config.enabled is False
+
 
 class TestSiteConfigDB:
     def test_create_site_config_db(self):


### PR DESCRIPTION
Cherry a staging de #199 (develop). Agrega `SiteConfig.enabled` (default True) — kill switch a nivel operador. Sin migración. **Mergear ANTES** que el companion de channel-services (CI instala base-models por branch). Companion: AIChatBet/chatbet-channel-services staging PR.