### PR TITLE
feat: add minimum_odds_recommended_combo to LocaleConfig (86ajk956j)

### DIFF
--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -391,6 +391,7 @@ class LocaleConfig(BaseModel):
     default_amount: Optional[str] = None
     default_desired_profit: Optional[str] = None
     default_minimum_odds: Optional[str] = None
+    minimum_odds_recommended_combo: Optional[str] = None
 
     @field_validator("currency")
     @classmethod
@@ -520,6 +521,7 @@ class SiteConfig(BaseModel):
             default_amount="",
             default_desired_profit="",
             default_minimum_odds="",
+            minimum_odds_recommended_combo="",
         )
     )
     features: FeaturesConfig = Field(


### PR DESCRIPTION
Allows each operator to configure the minimum total odds required when creating a combo, instead of the hardcoded value in the general agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional locale setting for the minimum recommended odds in combinations.
  * New site configurations now include a default value for this setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->