### PR TITLE
feat(message-template): add active_from/active_until schedule to Inli…

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -17,6 +17,17 @@ class InlineKeyboardButton(BaseModel):
     callback_data: Optional[str] = None
     url: Optional[str] = None
     title: Optional[str] = None
+    active_from: Optional[datetime] = None
+    active_until: Optional[datetime] = None
+
+    @field_validator("active_from", "active_until")
+    @classmethod
+    def _assume_utc_if_naive(cls, v: Optional[datetime]) -> Optional[datetime]:
+        """Frontend sends `datetime-local` values with no timezone; assume UTC rather
+        than let naive/aware comparisons blow up later in `is_expired()`."""
+        if v is not None and v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v
 
     @model_validator(mode="after")
     def _only_one_action(self) -> "InlineKeyboardButton":
@@ -29,6 +40,19 @@ class InlineKeyboardButton(BaseModel):
         if cd and len(cd) > 64:
             raise ValueError("callback_data must be <= 64 characters")
         return self
+
+    @model_validator(mode="after")
+    def _valid_schedule_range(self) -> "InlineKeyboardButton":
+        if self.active_from and self.active_until and self.active_from >= self.active_until:
+            raise ValueError("active_from must be before active_until")
+        return self
+
+    def is_expired(self, now: Optional[datetime] = None) -> bool:
+        """True once `active_until` has passed. A button with no `active_until` never expires."""
+        if self.active_until is None:
+            return False
+        reference = now or datetime.now(timezone.utc)
+        return self.active_until <= reference
 
 
 class InlineKeyboardMarkup(BaseModel):

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -59,6 +59,38 @@ class TestInlineKeyboardButton:
         with pytest.raises(ValueError):
             InlineKeyboardButton(text="", callback_data="test")
 
+    def test_button_without_schedule_never_expires(self):
+        button = InlineKeyboardButton(text="Test", callback_data="test")
+        assert button.active_from is None
+        assert button.active_until is None
+        assert button.is_expired() is False
+
+    def test_button_is_expired_after_active_until(self):
+        button = InlineKeyboardButton(
+            text="World Cup",
+            callback_data="world_cup",
+            active_until=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        assert button.is_expired(datetime(2026, 1, 2, tzinfo=timezone.utc)) is True
+        assert button.is_expired(datetime(2025, 12, 31, tzinfo=timezone.utc)) is False
+
+    def test_naive_schedule_datetimes_assumed_utc(self):
+        button = InlineKeyboardButton(
+            text="Test",
+            callback_data="test",
+            active_until=datetime(2026, 8, 1, 10, 0),
+        )
+        assert button.active_until.tzinfo == timezone.utc
+
+    def test_active_from_must_precede_active_until(self):
+        with pytest.raises(ValueError, match="active_from must be before active_until"):
+            InlineKeyboardButton(
+                text="Test",
+                callback_data="test",
+                active_from=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                active_until=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
 
 class TestInlineKeyboardMarkup:
     def test_create_empty_markup(self):


### PR DESCRIPTION
…neKeyboardButton (CU-86ajmq2zk)

Naive datetimes are assumed UTC so `is_expired()` never compares offset-naive against offset-aware datetimes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional scheduling windows for inline keyboard buttons.
  * Buttons can now automatically report whether they have expired.
  * Datetimes without timezone information are normalized to UTC.

* **Bug Fixes**
  * Added validation to prevent invalid schedules where the start time is later than or equal to the end time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->