### PR TITLE
fix: realign placed_bet default template placeholders (CU-86ajqxrjh)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -1250,7 +1250,7 @@ class MessageTemplates(BaseModel):
                 fixture_odds=MessageItem(text="Here are the odds for the fixture."),
                 unavailable_odds=MessageItem(text="Some odds are unavailable."),
                 placed_bet=MessageItem(
-                    text="Your bet has been placed successfully! 🤑 • Match: %1 • Bet Amount: %2 • Selection: %3 • Potential Win: %4 • Balance: %5"
+                    text="Your bet has been placed successfully! 🤑 • Match: %2 • Bet Amount: %3 • Selection: %4 • Odd: %5 • Potential Win: %6 • Balance: %7"
                 ),
                 placed_bet_menu=MessageItem(
                     text="Your bet has been placed! What would you like to do next?"

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1229,6 +1229,22 @@ class TestMessageTemplates:
         assert templates.validation.send_otp.text == "We've sent you an OTP."
         assert templates.bets.select_sport.text == "Select a sport"
 
+    def test_from_minimal_placed_bet_placeholder_order(self):
+        """CU-86ajqxrjh: placed_bet placeholders must match the %1-%8 scheme
+
+        used by TelegramMesssageServices.place_bet_message (%1=transaction_id,
+        %2=match, %3=amount, %4=selection, %5=odd, %6=profit, %7=balance).
+        A stale %1=Match/%2=Amount/... default shifted every field by one
+        position in the post-placement confirmation message.
+        """
+        text = MessageTemplates.from_minimal().bets.placed_bet.text
+        assert "Match: %2" in text
+        assert "Bet Amount: %3" in text
+        assert "Selection: %4" in text
+        assert "Potential Win: %6" in text
+        assert "Balance: %7" in text
+        assert "Match: %1" not in text
+
     def test_touch_method(self):
         templates = MessageTemplates()
         templates.updated_at = datetime(2020, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
Fixes [CU-86ajqxrjh](https://app.clickup.com/t/86ajqxrjh) — placed-bet confirmation fields shift by one position on companies using the `from_minimal()` default `placed_bet` template (observed on chatbeten staging).

## Root cause
`bet-bot`'s `TelegramMesssageServices.place_bet_message` (commit `545df3e0`, Oct 2025) added `transaction_id` as `%1` and shifted every other placeholder down (`%2`=match … `%7`=balance, `%8`=ticket). The **default** `placed_bet.text` seeded by `MessageTemplates.from_minimal()` here in chatbet-base-models was never updated to match — it still used the old `%1`=Match … `%5`=Balance scheme.

Any company relying on this default (no custom override persisted in DynamoDB) therefore renders every field one position off:
- `Match` (`%1`) → gets `transaction_id`
- `Bet Amount` (`%2`) → gets the match name
- `Selection` (`%3`) → gets the amount
- `Potential Win` (`%4`) → gets the selection name
- `Balance` (`%5`) → gets the odd (never references the real `%6` profit / `%7` balance at all)

This maps exactly to the reported chatbeten staging output.

## Fix
Realign the default `placed_bet.text` to the current `%1`-`%7` scheme (`%2`=match, `%3`=amount, `%4`=selection, `%5`=odd, `%6`=potential win, `%7`=balance).

## Follow-up (out of scope for this PR)
chatbeten's own `bets.placed_bet.text` is likely already persisted in DynamoDB with the stale scheme (frozen at company-creation time, predating the bet-bot placeholder shift) — a code fix here won't retroactively correct it. That needs a manual template edit via the operator-config mechanism (edit DynamoDB + `POST /update_config/chatbeten`) on staging, separate from this PR. Worth auditing other companies relying on the default template too.

## Test plan
- [x] Added `test_from_minimal_placed_bet_placeholder_order` asserting the corrected placeholder positions
- [x] `pytest tests/test_message_template.py` — 229 passed
- [x] Full suite `pytest` — 487 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected placeholder ordering in placed-bet success messages.
  * Ensured match, bet amount, selection, potential winnings, and balance details display in the correct positions.

* **Tests**
  * Added regression coverage to verify the corrected message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->