### PR TITLE
fix(message-template): realign placed_bet default placeholders (CU-86ajqxrjh)

### DIFF
--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -1226,7 +1226,7 @@ class MessageTemplates(BaseModel):
                 fixture_odds=MessageItem(text="Here are the odds for the fixture."),
                 unavailable_odds=MessageItem(text="Some odds are unavailable."),
                 placed_bet=MessageItem(
-                    text="Your bet has been placed successfully! 🤑 • Match: %1 • Bet Amount: %2 • Selection: %3 • Potential Win: %4 • Balance: %5"
+                    text="Your bet has been placed successfully! 🤑 • Match: %2 • Bet Amount: %3 • Selection: %4 • Odd: %5 • Potential Win: %6 • Balance: %7"
                 ),
                 placed_bet_menu=MessageItem(
                     text="Your bet has been placed! What would you like to do next?"

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1197,6 +1197,22 @@ class TestMessageTemplates:
         assert templates.validation.send_otp.text == "We've sent you an OTP."
         assert templates.bets.select_sport.text == "Select a sport"
 
+    def test_from_minimal_placed_bet_placeholder_order(self):
+        """CU-86ajqxrjh: placed_bet placeholders must match the %1-%8 scheme
+
+        used by TelegramMesssageServices.place_bet_message (%1=transaction_id,
+        %2=match, %3=amount, %4=selection, %5=odd, %6=profit, %7=balance).
+        A stale %1=Match/%2=Amount/... default shifted every field by one
+        position in the post-placement confirmation message.
+        """
+        text = MessageTemplates.from_minimal().bets.placed_bet.text
+        assert "Match: %2" in text
+        assert "Bet Amount: %3" in text
+        assert "Selection: %4" in text
+        assert "Potential Win: %6" in text
+        assert "Balance: %7" in text
+        assert "Match: %1" not in text
+
     def test_touch_method(self):
         templates = MessageTemplates()
         templates.updated_at = datetime(2020, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
Cherry-pick of merged develop fix #206 onto `main`, promoting per the develop→staging→main flow (in parallel with #208 to staging).

Realigns the default `placed_bet.text` template placeholders in `from_minimal()` to match `bet-bot`'s current `place_bet_message` code (%1=transaction_id, %2=match, %3=amount, %4=selection, %5=odd, %6=potential win, %7=balance). The stale default still used the old %1=Match/%2=Amount/%3=Selection/%4=Win/%5=Balance scheme, causing every field to render shifted by one position — and silently dropping potential win/balance entirely — in the post-placement confirmation message for any company relying on the default.

## Context
CU-86ajqxrjh. Prod's live company configs were already independently verified correct (audited via DynamoDB scan — no prod company was using the stale default). This PR closes the gap only for any *future* company created on prod, so it doesn't seed with the stale template.

## Test plan
- [x] `test_from_minimal_placed_bet_placeholder_order` passes on this branch
- [x] Clean cherry-pick (auto-merge, no conflicts) onto main

https://app.clickup.com/t/86ajqxrjh