### PR TITLE
release/2026-08-05 — Sprint 9 (base-models)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ chatbet-base-models/
 │   ├── site_config_model.py      # Site configuration
 │   ├── sportbook_config.py       # Sportsbook configuration
 │   ├── promotion_config.py       # Promotions management
-│   └── tutorial.py               # Tutorial videos management
+│   ├── tutorial.py               # Tutorial videos management
+│   └── onboarding_questions.py   # Operator-configured onboarding questions
 ├── tests/                        # Test suite (295 tests)
 ├── pyproject.toml                # Project configuration
 └── pytest.ini                    # Pytest configuration
@@ -62,6 +63,12 @@ Promotions management:
 Tutorial videos management:
 - `TutorialItemDB`: Tutorial item with s3_key, title, metadata
 - `TutorialsDB`: Array with add/remove/get methods
+
+### onboarding_questions.py
+Operator-configured profiling questions the agent weaves into conversation (SK `onboarding_questions`):
+- `OnboardingPhase`: `first_encounter` | `getting_to_know` | `window_frame`
+- `OnboardingQuestionItem`: one question — `agent_instruction` (an instruction, never a literal script), `storage_key`, `hook_hints`, optional date window
+- `OnboardingQuestions` / `OnboardingQuestionsDB`: container with `seed_default()` (the three questions the agent asks today) and `get_active_questions()`
 
 ## Key Features
 

--- a/chatbet_base_models/__init__.py
+++ b/chatbet_base_models/__init__.py
@@ -6,7 +6,7 @@ This package centralizes common data models used across
 multiple ChatBet projects.
 """
 
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 # Message Templates
 from .message_template import (
@@ -115,6 +115,15 @@ from .tutorial import (
     DeleteTutorialVideoResponse,
 )
 
+# Onboarding Questions
+from .onboarding_questions import (
+    ALLOWED_STORAGE_ROOTS,
+    OnboardingPhase,
+    OnboardingQuestionItem,
+    OnboardingQuestions,
+    OnboardingQuestionsDB,
+)
+
 __all__ = [
     # Version
     "__version__",
@@ -207,4 +216,10 @@ __all__ = [
     "GetTutorialVideosResponse",
     "UploadTutorialVideoResponse",
     "DeleteTutorialVideoResponse",
+    # Onboarding Questions
+    "ALLOWED_STORAGE_ROOTS",
+    "OnboardingPhase",
+    "OnboardingQuestionItem",
+    "OnboardingQuestions",
+    "OnboardingQuestionsDB",
 ]

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -17,6 +17,17 @@ class InlineKeyboardButton(BaseModel):
     callback_data: Optional[str] = None
     url: Optional[str] = None
     title: Optional[str] = None
+    active_from: Optional[datetime] = None
+    active_until: Optional[datetime] = None
+
+    @field_validator("active_from", "active_until")
+    @classmethod
+    def _assume_utc_if_naive(cls, v: Optional[datetime]) -> Optional[datetime]:
+        """Frontend sends `datetime-local` values with no timezone; assume UTC rather
+        than let naive/aware comparisons blow up later in `is_expired()`."""
+        if v is not None and v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v
 
     @model_validator(mode="after")
     def _only_one_action(self) -> "InlineKeyboardButton":
@@ -29,6 +40,19 @@ class InlineKeyboardButton(BaseModel):
         if cd and len(cd) > 64:
             raise ValueError("callback_data must be <= 64 characters")
         return self
+
+    @model_validator(mode="after")
+    def _valid_schedule_range(self) -> "InlineKeyboardButton":
+        if self.active_from and self.active_until and self.active_from >= self.active_until:
+            raise ValueError("active_from must be before active_until")
+        return self
+
+    def is_expired(self, now: Optional[datetime] = None) -> bool:
+        """True once `active_until` has passed. A button with no `active_until` never expires."""
+        if self.active_until is None:
+            return False
+        reference = now or datetime.now(timezone.utc)
+        return self.active_until <= reference
 
 
 class InlineKeyboardMarkup(BaseModel):

--- a/chatbet_base_models/message_template.py
+++ b/chatbet_base_models/message_template.py
@@ -1250,7 +1250,7 @@ class MessageTemplates(BaseModel):
                 fixture_odds=MessageItem(text="Here are the odds for the fixture."),
                 unavailable_odds=MessageItem(text="Some odds are unavailable."),
                 placed_bet=MessageItem(
-                    text="Your bet has been placed successfully! 🤑 • Match: %1 • Bet Amount: %2 • Selection: %3 • Potential Win: %4 • Balance: %5"
+                    text="Your bet has been placed successfully! 🤑 • Match: %2 • Bet Amount: %3 • Selection: %4 • Odd: %5 • Potential Win: %6 • Balance: %7"
                 ),
                 placed_bet_menu=MessageItem(
                     text="Your bet has been placed! What would you like to do next?"

--- a/chatbet_base_models/onboarding_questions.py
+++ b/chatbet_base_models/onboarding_questions.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timezone
+from enum import Enum
+from typing import Any, List, Optional
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+# Profile namespaces an answer may be written to. Validated at save time so a typo in
+# `storage_key` fails loudly in the back office instead of silently discarding the answer
+# the user gave (the agent could not route it anywhere). Extend when a new namespace exists.
+ALLOWED_STORAGE_ROOTS = ("memory_structured", "outreach_log")
+
+_KEY_RE = re.compile(r"^[a-z0-9_]+$")
+_STORAGE_KEY_RE = re.compile(r"^[a-z0-9_]+(\.[a-z0-9_]+)+$")
+
+
+class OnboardingPhase(str, Enum):
+    """When the agent should try to weave a question into the conversation."""
+
+    FIRST_ENCOUNTER = "first_encounter"  # the essentials, earliest interactions
+    GETTING_TO_KNOW = "getting_to_know"  # deeper detail, once the essentials are resolved
+    WINDOW_FRAME = "window_frame"  # bound to a date window (World Cup, finals); auto-retires
+
+
+# ===========================
+# Nested Model - Individual Question
+# ===========================
+class OnboardingQuestionItem(BaseModel):
+    """One profiling question an operator wants the agent to ask.
+
+    `agent_instruction` is an INSTRUCTION, never a literal script: the agent phrases it in the
+    company's configured language, tone and personality, and only when the moment feels natural.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(min_length=1, max_length=40, description="Stable identifier, snake_case")
+    label: str = Field(min_length=1, max_length=80, description="Internal name, shown in the back office")
+    agent_instruction: str = Field(min_length=1, max_length=1000)
+    phase: OnboardingPhase
+    storage_key: str = Field(min_length=1, max_length=120, description="Dotted profile path the answer lands on")
+    hook_hints: List[str] = Field(
+        default_factory=list,
+        description="Conversational cues that make the question feel natural",
+    )
+    required_for_personalization: bool = False
+    cooldown_override: Optional[int] = Field(
+        default=None, gt=0, description="Hours between asks for this question; None uses the global default"
+    )
+    protected: bool = Field(
+        default=False,
+        description="System-owned question (marketing consent): cannot be deleted nor have its storage_key changed",
+    )
+    enabled: bool = True
+    window_active_from: Optional[date] = None
+    window_active_to: Optional[date] = None
+
+    # Validators
+    @field_validator("key")
+    @classmethod
+    def _validate_key(cls, v: str) -> str:
+        """Keys are stable identifiers, so they must be slug-safe and case-insensitive-unique."""
+        cleaned = v.strip().lower()
+        if not _KEY_RE.match(cleaned):
+            raise ValueError(f"key must be snake_case (a-z, 0-9, _): {v!r}")
+        return cleaned
+
+    @field_validator("label", "agent_instruction")
+    @classmethod
+    def _validate_text(cls, v: str) -> str:
+        cleaned = v.strip()
+        if not cleaned:
+            raise ValueError("Value cannot be empty or only whitespace")
+        return cleaned
+
+    @field_validator("storage_key")
+    @classmethod
+    def _validate_storage_key(cls, v: str) -> str:
+        """A dotted path under a known profile namespace — see ALLOWED_STORAGE_ROOTS."""
+        cleaned = v.strip()
+        if not _STORAGE_KEY_RE.match(cleaned):
+            raise ValueError(f"storage_key must be a dotted snake_case path (e.g. memory_structured.name): {v!r}")
+        if cleaned.split(".", 1)[0] not in ALLOWED_STORAGE_ROOTS:
+            raise ValueError(f"storage_key must start with one of {ALLOWED_STORAGE_ROOTS}: {v!r}")
+        return cleaned
+
+    @field_validator("hook_hints")
+    @classmethod
+    def _validate_hook_hints(cls, v: List[str]) -> List[str]:
+        """Strip, drop empties, dedupe (order preserved) and bound size."""
+        if len(v) > 20:
+            raise ValueError("Maximum 20 hook_hints allowed")
+        seen: set[str] = set()
+        unique: List[str] = []
+        for hint in v:
+            h = hint.strip()
+            if not h:
+                continue
+            if len(h) > 200:
+                raise ValueError(f"hook_hint too long (max 200 chars): {h[:50]}...")
+            if h.lower() not in seen:
+                seen.add(h.lower())
+                unique.append(h)
+        return unique
+
+    @model_validator(mode="after")
+    def _validate_window(self) -> "OnboardingQuestionItem":
+        """The date window belongs to WINDOW_FRAME questions and only to them."""
+        if self.phase is OnboardingPhase.WINDOW_FRAME:
+            if not self.window_active_from or not self.window_active_to:
+                raise ValueError("window_active_from and window_active_to are required when phase is window_frame")
+            if self.window_active_to < self.window_active_from:
+                raise ValueError("window_active_to must be on or after window_active_from")
+        elif self.window_active_from or self.window_active_to:
+            raise ValueError("window_active_from/window_active_to are only valid when phase is window_frame")
+        return self
+
+    # Utility
+    def is_active_on(self, day: Optional[date] = None) -> bool:
+        """Whether this question may be asked on `day` — False once a window has closed."""
+        if not self.enabled:
+            return False
+        if self.phase is not OnboardingPhase.WINDOW_FRAME:
+            return True
+        today = day or datetime.now(timezone.utc).date()
+        return self.window_active_from <= today <= self.window_active_to
+
+
+# ===========================
+# Main Configuration - Array Container
+# ===========================
+class OnboardingQuestions(BaseModel):
+    """The set of profiling questions configured for a company."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    questions: List[OnboardingQuestionItem] = Field(
+        default_factory=list,
+        description="All configured questions, any phase",
+    )
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    # Array-level validation
+    @field_validator("questions")
+    @classmethod
+    def _validate_questions(cls, v: List[OnboardingQuestionItem]) -> List[OnboardingQuestionItem]:
+        """Sanity bound plus uniqueness of both identifiers.
+
+        Duplicate `storage_key` would make two questions overwrite each other's answer, so it is
+        rejected here rather than debugged later. The soft operator guidance (warn above 5
+        first-encounter / 15 required) is a back-office concern, not a validation error.
+        """
+        if len(v) > 50:
+            raise ValueError("Maximum 50 questions allowed")
+        keys = [q.key for q in v]
+        if len(keys) != len(set(keys)):
+            raise ValueError("Duplicate key found in questions array")
+        storage_keys = [q.storage_key for q in v]
+        if len(storage_keys) != len(set(storage_keys)):
+            raise ValueError("Duplicate storage_key found in questions array")
+        return v
+
+    # Factory methods
+    @classmethod
+    def from_minimal(cls) -> "OnboardingQuestions":
+        """Create an empty question set."""
+        now = datetime.now(timezone.utc)
+        return cls(questions=[], created_at=now, updated_at=now)
+
+    @classmethod
+    def seed_default(cls) -> "OnboardingQuestions":
+        """The three questions the agent asks today, as configuration.
+
+        Used to bootstrap a company that has no record yet, so behaviour is unchanged from the
+        hardcoded flow. `consent` is protected: it is the opt-in that legally enables proactive
+        messaging, so an operator must not be able to delete it or repoint its storage_key.
+        """
+        return cls(
+            questions=[
+                OnboardingQuestionItem(
+                    key="name",
+                    label="Preferred name",
+                    agent_instruction=(
+                        "Ask the USER what their name is — how you should address them personally. "
+                        "It is strictly about the USER's own name; never your own."
+                    ),
+                    phase=OnboardingPhase.FIRST_ENCOUNTER,
+                    storage_key="memory_structured.name",
+                    required_for_personalization=True,
+                ),
+                OnboardingQuestionItem(
+                    key="consent",
+                    label="Marketing consent",
+                    agent_instruction=(
+                        "Ask whether the USER authorizes receiving offers and promotions through this channel."
+                    ),
+                    phase=OnboardingPhase.FIRST_ENCOUNTER,
+                    storage_key="outreach_log.promo_consent",
+                    required_for_personalization=True,
+                    protected=True,
+                ),
+                OnboardingQuestionItem(
+                    key="tournament",
+                    label="Favorite tournament",
+                    agent_instruction="Ask which tournament or league is the USER's favorite.",
+                    phase=OnboardingPhase.FIRST_ENCOUNTER,
+                    storage_key="memory_structured.favorite_tournaments",
+                    hook_hints=["the user mentions a team", "the user asks odds on a specific match"],
+                ),
+            ]
+        )
+
+    # Utility methods
+    def touch(self) -> None:
+        """Update the updated_at timestamp"""
+        self.updated_at = datetime.now(timezone.utc)
+
+    def get_question(self, key: str) -> Optional[OnboardingQuestionItem]:
+        """Get a question by key"""
+        for question in self.questions:
+            if question.key == key:
+                return question
+        return None
+
+    def remove_question(self, key: str) -> bool:
+        """Remove a question by key. Returns True if found and removed.
+
+        A `protected` question is never removed — it is system-owned.
+        """
+        for i, question in enumerate(self.questions):
+            if question.key == key:
+                if question.protected:
+                    raise ValueError(f"Question {key!r} is protected and cannot be removed")
+                self.questions.pop(i)
+                self.touch()
+                return True
+        return False
+
+    def get_active_questions(
+        self, *, phase: Optional[OnboardingPhase] = None, day: Optional[date] = None
+    ) -> List[OnboardingQuestionItem]:
+        """Questions askable on `day`: enabled, and inside their window when time-bound."""
+        return [
+            q
+            for q in self.questions
+            if q.is_active_on(day) and (phase is None or q.phase is phase)
+        ]
+
+    def to_dynamodb_item(self, *, drop_none: bool = True) -> dict:
+        """Serialize to DynamoDB-compatible dict"""
+
+        def ser(x: Any) -> Any:
+            if isinstance(x, datetime):
+                return x.isoformat()
+            if isinstance(x, date):
+                return x.isoformat()
+            if isinstance(x, Enum):
+                return x.value
+            if isinstance(x, dict):
+                out = {k: ser(v) for k, v in x.items()}
+                return {k: v for k, v in out.items() if not (drop_none and v is None)}
+            if isinstance(x, list):
+                return [ser(v) for v in x]
+            if hasattr(x, "model_dump"):
+                return ser(x.model_dump())
+            return x  # primitives
+
+        return ser(self.model_dump())
+
+
+# ===========================
+# DynamoDB Variant
+# ===========================
+class OnboardingQuestionsDB(OnboardingQuestions):
+    """DynamoDB variant with PK/SK"""
+
+    PK: Optional[str] = Field(default=None, description="Partition key")
+    SK: Optional[str] = Field(default=None, description="Sort key")
+
+    @classmethod
+    def from_minimal(cls, company_id: str) -> "OnboardingQuestionsDB":
+        """Create an empty question set for a company"""
+        base = OnboardingQuestions.from_minimal()
+        return cls(
+            **base.model_dump(),
+            PK=f"company#{company_id}",
+            SK="onboarding_questions",
+        )
+
+    @classmethod
+    def seed_default(cls, company_id: str) -> "OnboardingQuestionsDB":
+        """Seed a company with the three questions the agent asks today"""
+        base = OnboardingQuestions.seed_default()
+        return cls(
+            **base.model_dump(),
+            PK=f"company#{company_id}",
+            SK="onboarding_questions",
+        )
+
+    @model_validator(mode="after")
+    def _ensure_keys(self) -> "OnboardingQuestionsDB":
+        """Ensure PK and SK are set"""
+        if not self.PK or not self.SK:
+            raise ValueError("PK and SK are required for OnboardingQuestionsDB")
+        return self
+
+    # Inherits all utility methods from OnboardingQuestions

--- a/chatbet_base_models/site_config_model.py
+++ b/chatbet_base_models/site_config_model.py
@@ -439,6 +439,10 @@ class FeaturesConfig(BaseModel):
         default=False,
         description="Enable WhatsApp detected-number login confirm screen (per-company rollout). When False, WhatsApp users keep the type-the-number flow.",
     )
+    minimal_buttons: Optional[bool] = Field(
+        default=False,
+        description="Minimal-buttons / conversational experiment (per-company rollout, Spike CU-86ahdec0v). When True, the agent replies text-first and channel-services renders no navigation buttons (only the bet-summary Confirmar button). When False, the standard button-driven flow is unchanged.",
+    )
     fixture_range_days: Optional[int] = Field(
         default=7,
         ge=1,
@@ -537,6 +541,7 @@ class SiteConfig(BaseModel):
             skip_pre_auth_validation=False,
             live=False,
             whatsapp_detected_login=False,
+            minimal_buttons=False,
             fixture_range_days=7,
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbet-base-models"
-version = "1.0.2"
+version = "1.1.0"
 description = "Modelos base de Pydantic para aplicaciones ChatBet"
 authors = [{name = "ChatBet Team", email = "tech@chatbet.gg"}]
 license = {text = "MIT"}

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -1229,6 +1229,22 @@ class TestMessageTemplates:
         assert templates.validation.send_otp.text == "We've sent you an OTP."
         assert templates.bets.select_sport.text == "Select a sport"
 
+    def test_from_minimal_placed_bet_placeholder_order(self):
+        """CU-86ajqxrjh: placed_bet placeholders must match the %1-%8 scheme
+
+        used by TelegramMesssageServices.place_bet_message (%1=transaction_id,
+        %2=match, %3=amount, %4=selection, %5=odd, %6=profit, %7=balance).
+        A stale %1=Match/%2=Amount/... default shifted every field by one
+        position in the post-placement confirmation message.
+        """
+        text = MessageTemplates.from_minimal().bets.placed_bet.text
+        assert "Match: %2" in text
+        assert "Bet Amount: %3" in text
+        assert "Selection: %4" in text
+        assert "Potential Win: %6" in text
+        assert "Balance: %7" in text
+        assert "Match: %1" not in text
+
     def test_touch_method(self):
         templates = MessageTemplates()
         templates.updated_at = datetime(2020, 1, 1, tzinfo=timezone.utc)

--- a/tests/test_message_template.py
+++ b/tests/test_message_template.py
@@ -59,6 +59,38 @@ class TestInlineKeyboardButton:
         with pytest.raises(ValueError):
             InlineKeyboardButton(text="", callback_data="test")
 
+    def test_button_without_schedule_never_expires(self):
+        button = InlineKeyboardButton(text="Test", callback_data="test")
+        assert button.active_from is None
+        assert button.active_until is None
+        assert button.is_expired() is False
+
+    def test_button_is_expired_after_active_until(self):
+        button = InlineKeyboardButton(
+            text="World Cup",
+            callback_data="world_cup",
+            active_until=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        assert button.is_expired(datetime(2026, 1, 2, tzinfo=timezone.utc)) is True
+        assert button.is_expired(datetime(2025, 12, 31, tzinfo=timezone.utc)) is False
+
+    def test_naive_schedule_datetimes_assumed_utc(self):
+        button = InlineKeyboardButton(
+            text="Test",
+            callback_data="test",
+            active_until=datetime(2026, 8, 1, 10, 0),
+        )
+        assert button.active_until.tzinfo == timezone.utc
+
+    def test_active_from_must_precede_active_until(self):
+        with pytest.raises(ValueError, match="active_from must be before active_until"):
+            InlineKeyboardButton(
+                text="Test",
+                callback_data="test",
+                active_from=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                active_until=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
 
 class TestInlineKeyboardMarkup:
     def test_create_empty_markup(self):


### PR DESCRIPTION
Weekly release staging→main for Sprint 9. **Merge FIRST** (consumers install base-models in CI).

Additive / backwards-compatible model changes:
- OnboardingQuestions config model (backs validated Onboarding 2.0 — CU-86ajt98xd/86ajt5vvc)
- features.minimal_buttons flag (inert; the channel feature itself is excluded this cycle, field is harmless/optional)

Merge is CLEAN; main is an ancestor of the release branch.